### PR TITLE
Update .gitignore with comprehensive Node.js patterns #29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+# Environment variable files
 .env
+.env.*
+!.env.example
 
 # Logs
 logs
@@ -9,10 +12,56 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependencies
 node_modules
+jspm_packages/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional stylelint cache
+.stylelintcache
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# Build output
 dist
 dist-ssr
 *.local
+
+# Vite files
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
+.vite/
 
 # Editor directories and files
 .vscode/*
@@ -29,3 +78,15 @@ dist-ssr
 cypress/screenshots
 cypress/videos
 cypress/downloads
+
+# pnpm
+.pnpm-store
+
+# yarn v3
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions


### PR DESCRIPTION
Compare against GitHub's Node.gitignore template and add:
- Diagnostic reports, runtime data (pids, seeds)
- Coverage directories (.nyc_output, coverage, *.lcov)
- TypeScript build cache (*.tsbuildinfo)
- npm/eslint/stylelint caches
- Vite timestamp and .vite/ directory
- yarn v3 and pnpm patterns
- Environment file patterns (.env.*)
- npm pack output (*.tgz)

Closes #29