### PR TITLE
Add game reducer, reusable persistence, and state management docs #45

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The reasoning for each item is included below.
 src/
 ├── client/                 # Frontend React application
 │   ├── components/
-│   │   ├── data/          # Redux store, reducers, and actions
+│   │   ├── data/          # Redux store, reducers, and actions (see [data/README.md](src/client/components/data/README.md))
 │   │   └── ui/            # Reusable UI components
 │   ├── pages/             # Page components (Home, About, etc.)
 │   ├── shared/            # Client-side utilities and constants

--- a/src/client/components/data/README.md
+++ b/src/client/components/data/README.md
@@ -1,0 +1,71 @@
+# State Management
+
+This directory contains the Redux Toolkit state management layer for the application.
+
+## Architecture
+
+```
+data/
+├── store.ts           # Redux store configuration
+├── persistence.ts     # Reusable encrypted localStorage middleware
+├── player.ts          # Player slice (authentication, score)
+├── player-actions.ts  # Player async thunks and sync actions
+├── game.ts            # Game slice (level, high score, games played)
+└── README.md          # This file
+```
+
+## Why Redux?
+
+Redux remains the most battle-tested solution for complex state management. Its strict unidirectional data flow, devtools, and middleware ecosystem are excellent at scale. Redux Toolkit simplifies the traditional Redux ceremony with slices, which combine actions, reducers, and initial state in one place.
+
+For this boilerplate, Redux provides:
+- **DevTools visibility** — useful for debugging "why does the app think X is Y"
+- **Middleware ecosystem** — the persistence middleware encrypts and saves state automatically
+- **Predictable updates** — strict unidirectional flow prevents subtle bugs
+- **Scalability** — as the app grows, Redux patterns scale well
+
+## When to use what
+
+| Approach | When to use |
+|---|---|
+| `useState` | Component-local UI state (form inputs, toggles, modals) |
+| `useReducer` | Complex component-local state with multiple related values |
+| Custom hook | Reusable stateful logic shared across components |
+| Context + hook | State shared by a subtree but not the whole app (e.g. a form wizard) |
+| Redux | Global state that persists, needs devtools, or drives many components |
+
+**Rule of thumb**: start with `useState`. If state logic becomes complex within a component, reach for `useReducer`. If multiple components need the same state, consider whether it's a subtree concern (Context) or truly global (Redux).
+
+## Persistence
+
+State persistence is handled by `createPersistMiddleware` in `persistence.ts`. It:
+
+1. Listens for every Redux action
+2. Serializes the specified slices to JSON
+3. Encrypts the JSON with CryptoJS AES
+4. Stores the encrypted string in `localStorage`
+
+To persist a new slice, add its key to the `sliceKeys` array in `store.ts`:
+
+```ts
+const persistMiddleware = createPersistMiddleware({
+  sliceKeys: ['player', 'game', 'yourNewSlice'],
+});
+```
+
+The encryption key is fetched from the server during initialization and is only available after authentication.
+
+## Adding a new slice
+
+1. Create a new file (e.g. `settings.ts`) following the pattern in `game.ts`
+2. Add the reducer to `store.ts`
+3. If the slice should persist, add its key to `sliceKeys` in `store.ts`
+4. If the slice needs to restore from localStorage, add an `extraReducers` case for `initPlayer.fulfilled`
+
+## Common pitfalls
+
+- **Over-normalizing state**: Don't create separate actions for every conceivable state change. Use RTK's slice pattern which keeps things concise.
+- **Putting everything in Redux**: Component-local state (form inputs, UI toggles) does not belong in the store. Only state that is truly global should be in Redux.
+- **Deriving state in components**: Use selectors (or `createSelector` from RTK) to derive computed values. Don't store derived data in the state.
+- **Mutating state outside of reducers**: RTK uses Immer, so mutations inside reducers are safe. Outside of reducers, always treat state as immutable.
+- **Ignoring DevTools**: Redux DevTools is one of the biggest advantages — use it for debugging.

--- a/src/client/components/data/game.ts
+++ b/src/client/components/data/game.ts
@@ -1,0 +1,47 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { initPlayer, PlayerState } from './player-actions';
+
+export const defaultGameState = {
+  level: 1,
+  highScore: 0,
+  gamesPlayed: 0,
+};
+
+export type GameState = typeof defaultGameState;
+
+interface InitResult {
+  player: PlayerState;
+  game: GameState;
+}
+
+export const gameSlice = createSlice({
+  name: 'game',
+  initialState: defaultGameState,
+  reducers: {
+    nextLevel: (state) => {
+      state.level += 1;
+    },
+    resetLevel: (state) => {
+      state.level = 1;
+    },
+    recordScore: (state, action: PayloadAction<number>) => {
+      state.gamesPlayed += 1;
+      if (action.payload > state.highScore) {
+        state.highScore = action.payload;
+      }
+    },
+    resetGame: (state) => {
+      state.level = defaultGameState.level;
+      state.highScore = defaultGameState.highScore;
+      state.gamesPlayed = defaultGameState.gamesPlayed;
+    },
+  },
+  extraReducers: builder => {
+    builder.addCase(initPlayer.fulfilled, (state, action: PayloadAction<InitResult>) => {
+      Object.assign(state, action.payload.game);
+    });
+  },
+});
+
+export const { nextLevel, resetLevel, recordScore, resetGame } = gameSlice.actions;
+export default gameSlice.reducer;

--- a/src/client/components/data/persistence.ts
+++ b/src/client/components/data/persistence.ts
@@ -1,0 +1,50 @@
+import { Middleware } from '@reduxjs/toolkit';
+import { encrypt } from '@/client/shared/encryption';
+import { LOCAL_STORAGE_ID } from '@/client/shared/constants';
+
+interface PersistableState {
+  encryptionKey: string | null;
+}
+
+interface PersistConfig {
+  sliceKeys: string[];
+}
+
+/**
+ * Creates a reusable middleware that persists specified Redux slices
+ * to encrypted localStorage. Any slice listed in `sliceKeys` will be
+ * saved whenever the store updates.
+ *
+ * Usage:
+ *   createPersistMiddleware({ sliceKeys: ['player', 'game'] })
+ */
+export const createPersistMiddleware = (config: PersistConfig): Middleware => {
+  return storeAPI => next => action => {
+    const result = next(action);
+
+    setTimeout(() => {
+      try {
+        const state = storeAPI.getState() as Record<string, PersistableState>;
+        const { encryptionKey } = state.player;
+
+        if (encryptionKey) {
+          const stateToPersist: Record<string, unknown> = {};
+          for (const key of config.sliceKeys) {
+            stateToPersist[key] = state[key];
+          }
+
+          const encryptedState = encrypt(JSON.stringify(stateToPersist), encryptionKey);
+          if (encryptedState) {
+            localStorage.setItem(LOCAL_STORAGE_ID, encryptedState);
+          } else {
+            console.error('Failed to encrypt state');
+          }
+        }
+      } catch (error) {
+        console.error('Failed to save state to localStorage:', error);
+      }
+    }, 0);
+
+    return result;
+  };
+};

--- a/src/client/components/data/player.ts
+++ b/src/client/components/data/player.ts
@@ -1,19 +1,24 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { defaultState, initPlayer, playerActions } from './player-actions';
+import { defaultState, initPlayer, playerActions, PlayerState } from './player-actions';
+import { GameState } from './game';
+
+interface InitResult {
+  player: PlayerState;
+  game: GameState;
+}
 
 export const playerSlice = createSlice({
   name: 'player',
   initialState: defaultState,
-  reducers: playerActions, // non-async actions
+  reducers: playerActions,
   extraReducers: builder => {
-    // Handle async actions
     builder
       .addCase(initPlayer.pending, state => {
         state.loading = true;
         state.error = null;
       })
-      .addCase(initPlayer.fulfilled, (state, action: PayloadAction<unknown>) => {
-        Object.assign(state, action.payload);
+      .addCase(initPlayer.fulfilled, (state, action: PayloadAction<InitResult>) => {
+        Object.assign(state, action.payload.player);
         state.loading = false;
       })
       .addCase(initPlayer.rejected, state => {

--- a/src/client/components/data/store.ts
+++ b/src/client/components/data/store.ts
@@ -1,43 +1,20 @@
-import { configureStore, Middleware } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 import playerReducer from './player';
-import { encrypt } from '@/client/shared/encryption';
-import { PlayerState } from './player-actions';
-import { LOCAL_STORAGE_ID } from '@/client/shared/constants';
+import gameReducer from './game';
+import { createPersistMiddleware } from './persistence';
 
-type GenericObject = Record<string, unknown>;
-interface LocalState { player: PlayerState}
-
-const saveToLocalStorage: Middleware<GenericObject, LocalState> = storeAPI => next => action => {
-  // debounce to ensure we get the latest state
-  setTimeout(() => {
-    try {
-      const { player } = storeAPI.getState();
-      const { encryptionKey } = player;
-      if (encryptionKey) {
-        const encryptedState = encrypt(JSON.stringify(player), encryptionKey);
-        if (encryptedState) {
-          localStorage.setItem(LOCAL_STORAGE_ID, encryptedState);
-        } else {
-          console.error('Failed to encrypt state');
-        }
-      }
-    } catch (error) {
-      console.error('Failed to save state to localStorage:', error);
-    }
-  }, 0);
-  return next(action);
-};
+const persistMiddleware = createPersistMiddleware({
+  sliceKeys: ['player', 'game'],
+});
 
 export const store = configureStore({
   reducer: {
-    // Add additional reducers here
-    player: playerReducer
+    player: playerReducer,
+    game: gameReducer,
   },
   middleware: getDefaultMiddleware => getDefaultMiddleware()
-    // Add any additional middleware here
-    .concat(saveToLocalStorage),
+    .concat(persistMiddleware),
 });
 
-// Infer the `RootState` and `AppDispatch` types from the store itself
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch


### PR DESCRIPTION
- Add game slice with level, highScore, and gamesPlayed state
- Extract persistence logic into reusable createPersistMiddleware
- Refactor initPlayer to support multi-slice persistence format
- Maintain backward compatibility with old flat localStorage format
- Add comprehensive README documenting rationale, patterns, and pitfalls
- Update main README with link to state management docs

Closes #45