### PR TITLE
Add React 19 document metadata to all page components #49

### DIFF
--- a/src/client/pages/About.tsx
+++ b/src/client/pages/About.tsx
@@ -7,6 +7,8 @@ import { PublicHeader } from '../components/layout/header';
 const About = () => {
   return (
     <>
+      <title>About - 2026 Boilerplate</title>
+      <meta name="description" content="Learn about the 2026 Boilerplate — a full-stack starter kit with React, Express, Redux, and Chakra UI" />
       <PublicHeader />
       <Container maxW="container.md" py={8}>
         <VStack gap={6} align="stretch">

--- a/src/client/pages/Home.tsx
+++ b/src/client/pages/Home.tsx
@@ -6,6 +6,8 @@ import { Link as RouterLink } from 'react-router';
 const Home = () => {
   return (
     <>
+      <title>2026 Boilerplate</title>
+      <meta name="description" content="A modern, full-stack web application starter kit with TypeScript, React, and Node.js" />
       <PublicHeader />
       <Container maxW="container.md" py={8}>
         <VStack gap={6} align="stretch">

--- a/src/client/pages/Login.tsx
+++ b/src/client/pages/Login.tsx
@@ -14,6 +14,8 @@ import { PublicHeader } from '../components/layout/header';
 const Login = () => {
   return (
     <>
+      <title>Login - 2026 Boilerplate</title>
+      <meta name="description" content="Sign in to the 2026 Boilerplate application" />
       <PublicHeader />
       <Container maxW="container.sm" py={8}>
         <Box as="main" role="main">

--- a/src/client/pages/NotFound.tsx
+++ b/src/client/pages/NotFound.tsx
@@ -6,6 +6,7 @@ import { PublicHeader } from '../components/layout/header';
 const NotFound = () => {
   return (
     <>
+      <title>Page Not Found - 2026 Boilerplate</title>
       <PublicHeader />
       <Container maxW="container.md" py={8}>
         <VStack gap={6} align="center">

--- a/src/client/pages/Privacy.tsx
+++ b/src/client/pages/Privacy.tsx
@@ -6,6 +6,8 @@ import { PublicHeader } from '../components/layout/header';
 const Privacy = () => {
   return (
     <>
+      <title>Privacy Policy - 2026 Boilerplate</title>
+      <meta name="description" content="Privacy policy for the 2026 Boilerplate application" />
       <PublicHeader />
       <Container maxW="container.md" py={8}>
         <VStack gap={6} align="stretch">

--- a/src/client/pages/Product.tsx
+++ b/src/client/pages/Product.tsx
@@ -11,6 +11,8 @@ const Product = () => {
 
   return (
     <>
+      <title>Product - 2026 Boilerplate</title>
+      <meta name="description" content="Product dashboard for the 2026 Boilerplate application" />
       <PrivateHeader />
       <Container maxW="container.md" py={8}>
         <VStack gap={6} align="stretch">

--- a/src/client/pages/Terms.tsx
+++ b/src/client/pages/Terms.tsx
@@ -7,6 +7,8 @@ import { PublicHeader } from '../components/layout/header';
 const Terms = () => {
   return (
     <>
+      <title>Terms of Service - 2026 Boilerplate</title>
+      <meta name="description" content="Terms of service for the 2026 Boilerplate application" />
       <PublicHeader />
       <Container maxW="container.md" py={8}>
         <VStack gap={6} align="stretch">


### PR DESCRIPTION
Use React 19's built-in document metadata support to add per-page <title> and <meta name='description'> tags to every page component. React 19 automatically hoists these from component render output to the <head> element.

Pages updated: Home, About, Login, Product, Privacy, Terms, NotFound. The static meta tags in index.html remain as SSR/fallback defaults.

Closes #49