### PR TITLE
Migrate from React Router to TanStack Router #46

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@emotion/react": "11.14.0",
         "@emotion/styled": "11.14.1",
         "@reduxjs/toolkit": "2.9.0",
+        "@tanstack/react-router": "^1.162.9",
+        "@tanstack/router-devtools": "^1.162.9",
         "cookie-parser": "1.4.7",
         "crypto-js": "4.2.0",
         "ejs": "3.1.10",
@@ -27,7 +29,6 @@
         "react-error-boundary": "6.0.0",
         "react-icons": "5.5.0",
         "react-redux": "9.2.0",
-        "react-router": "7.13.0",
         "tsx": "4.20.6",
         "typescript": "5.9.3",
         "vite-express": "0.21.1"
@@ -1992,6 +1993,177 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/history": {
+      "version": "1.161.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.161.4.tgz",
+      "integrity": "sha512-Kp/WSt411ZWYvgXy6uiv5RmhHrz9cAml05AQPrtdAp7eUqvIDbMGPnML25OKbzR3RJ1q4wgENxDTvlGPa9+Mww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-router": {
+      "version": "1.162.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.162.9.tgz",
+      "integrity": "sha512-APbwKAF+YgSNpHAaA+FdgrmfI/7+qa9hApuVO9+P0IVksJayNIWFQ/6AFG90WQiTYWk64RI1R9cFV2K9Z+j2pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.161.4",
+        "@tanstack/react-store": "^0.9.1",
+        "@tanstack/router-core": "1.162.9",
+        "isbot": "^5.1.22",
+        "tiny-invariant": "^1.3.3",
+        "tiny-warning": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-router-devtools": {
+      "version": "1.162.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router-devtools/-/react-router-devtools-1.162.9.tgz",
+      "integrity": "sha512-8xDqykw8MYWj4JoNfiJR/ZnocRBlfFeDSOQWVoWlnZKlciLCJ9dVfXuXQJlDlWr3JdmsWyyRvruZBnYr1YlUcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/router-devtools-core": "1.162.9"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-router": "^1.162.9",
+        "@tanstack/router-core": "^1.162.9",
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@tanstack/router-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.9.1.tgz",
+      "integrity": "sha512-YzJLnRvy5lIEFTLWBAZmcOjK3+2AepnBv/sr6NZmiqJvq7zTQggyK99Gw8fqYdMdHPQWXjz0epFKJXC+9V2xDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "0.9.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/router-core": {
+      "version": "1.162.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.162.9.tgz",
+      "integrity": "sha512-eG7C0oVtZbFOkfvsaF8UyGuNjEc1BfIfD5EzQNwG4vqLKOAyY5SMFBCNjabAi2sglRhL0ZOwKon1SExusU5fxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.161.4",
+        "@tanstack/store": "^0.9.1",
+        "cookie-es": "^2.0.0",
+        "seroval": "^1.4.2",
+        "seroval-plugins": "^1.4.2",
+        "tiny-invariant": "^1.3.3",
+        "tiny-warning": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/router-devtools": {
+      "version": "1.162.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-devtools/-/router-devtools-1.162.9.tgz",
+      "integrity": "sha512-ggR71Dy2hX404EOqZ7LqP2v/apbnz/zkBJtTRCXQIgeTWaoODsBXAoAtd2RA9RM6Wp5/qg3TkkJzjZmncEYKmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/react-router-devtools": "1.162.9",
+        "clsx": "^2.1.1",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-router": "^1.162.9",
+        "csstype": "^3.0.10",
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "csstype": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/router-devtools-core": {
+      "version": "1.162.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-devtools-core/-/router-devtools-core-1.162.9.tgz",
+      "integrity": "sha512-fX54Aub/mS9KVrWy/CSe5+vu/pSez45RojzBZYK4KLMA8HsTxQ4/jjBfHwGg6FaqXKL52b72f4BAB+Cx559rIA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "goober": "^2.1.16",
+        "tiny-invariant": "^1.3.3"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/router-core": "^1.162.9",
+        "csstype": "^3.0.10"
+      },
+      "peerDependenciesMeta": {
+        "csstype": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.1.tgz",
+      "integrity": "sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4229,6 +4401,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4326,6 +4507,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-es": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
+      "integrity": "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==",
+      "license": "MIT"
     },
     "node_modules/cookie-parser": {
       "version": "1.4.7",
@@ -5893,6 +6080,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -6311,6 +6507,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isbot": {
+      "version": "5.1.35",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.35.tgz",
+      "integrity": "sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/isexe": {
@@ -7533,41 +7738,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-router": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router/node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7901,6 +8071,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/seroval": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
+      "integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.0.tgz",
+      "integrity": "sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
@@ -7915,12 +8106,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -8214,6 +8399,18 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -8659,9 +8856,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@reduxjs/toolkit": "2.9.0",
+    "@tanstack/react-router": "^1.162.9",
+    "@tanstack/router-devtools": "^1.162.9",
     "cookie-parser": "1.4.7",
     "crypto-js": "4.2.0",
     "ejs": "3.1.10",
@@ -40,7 +42,6 @@
     "react-error-boundary": "6.0.0",
     "react-icons": "5.5.0",
     "react-redux": "9.2.0",
-    "react-router": "7.13.0",
     "tsx": "4.20.6",
     "typescript": "5.9.3",
     "vite-express": "0.21.1"

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,19 +1,10 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { RootState, AppDispatch } from './components/data/store';
-import { useEffect, lazy, Suspense } from 'react';
+import { type RootState, type AppDispatch } from './components/data/store';
+import { useEffect } from 'react';
 import { initPlayer } from './components/data/player-actions';
 import { ErrorPage } from './components/ui/error-page';
 import { LoadingSpinner } from './components/ui/loading-spinner';
-import { Routes, Route } from 'react-router';
-import Home from './pages/Home';
-
-// Lazy load pages for better performance
-const Product = lazy(() => import('./pages/Product'));
-const About = lazy(() => import('./pages/About'));
-const Login = lazy(() => import('./pages/Login'));
-const Privacy = lazy(() => import('./pages/Privacy'));
-const Terms = lazy(() => import('./pages/Terms'));
-const NotFound = lazy(() => import('./pages/NotFound'));
+import { Outlet } from '@tanstack/react-router';
 
 const App = () => {
   const { loading, error } = useSelector((state: RootState) => state.player);
@@ -26,19 +17,7 @@ const App = () => {
   if (loading) return <LoadingSpinner />;
   if (error) return <ErrorPage message={error} />;
 
-  return (
-    <Suspense fallback={<LoadingSpinner />}>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/product" element={<Product />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/privacy" element={<Privacy />} />
-        <Route path="/terms" element={<Terms />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </Suspense>
-  );
+  return <Outlet />;
 };
 
 export default App;

--- a/src/client/components/layout/footer.tsx
+++ b/src/client/components/layout/footer.tsx
@@ -1,5 +1,5 @@
-import { Box, Flex, Text, Link } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router';
+import { Box, Flex, Text, Link as ChakraLink } from '@chakra-ui/react';
+import { Link } from '@tanstack/react-router';
 
 export const Footer = () => {
   return (
@@ -9,16 +9,16 @@ export const Footer = () => {
           &copy; {new Date().getFullYear()} [insert project name here]. All rights reserved.
         </Text>
         <Flex gap={4}>
-          <RouterLink to="/privacy">
-            <Link fontSize="sm" color="gray.600" _hover={{ color: 'gray.800' }}>
+          <Link to="/privacy">
+            <ChakraLink fontSize="sm" color="gray.600" _hover={{ color: 'gray.800' }}>
               Privacy Policy
-            </Link>
-          </RouterLink>
-          <RouterLink to="/terms">
-            <Link fontSize="sm" color="gray.600" _hover={{ color: 'gray.800' }}>
+            </ChakraLink>
+          </Link>
+          <Link to="/terms">
+            <ChakraLink fontSize="sm" color="gray.600" _hover={{ color: 'gray.800' }}>
               Terms of Service
-            </Link>
-          </RouterLink>
+            </ChakraLink>
+          </Link>
         </Flex>
       </Flex>
     </Box>

--- a/src/client/components/layout/header.tsx
+++ b/src/client/components/layout/header.tsx
@@ -1,22 +1,22 @@
 import { Box, Flex, Heading, Button } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router';
+import { Link } from '@tanstack/react-router';
 
 export const PublicHeader = () => {
   return (
     <Box as="header" bg="gray.100" py={4} px={8} boxShadow="sm">
       <Flex justify="space-between" align="center">
         <Heading as="h1" size="lg">
-          <RouterLink to="/">2026 Boilerplate</RouterLink>
+          <Link to="/">2026 Boilerplate</Link>
         </Heading>
         <Flex gap={4}>
-          <Button as={RouterLink} asChild variant="ghost">
-            <RouterLink to="/">Home</RouterLink>
-          </Button>
-          <Button as={RouterLink} asChild variant="ghost">
-            <RouterLink to="/about">About</RouterLink>
+          <Button asChild variant="ghost">
+            <Link to="/">Home</Link>
           </Button>
           <Button asChild variant="ghost">
-            <RouterLink to="/login">Login</RouterLink>
+            <Link to="/about">About</Link>
+          </Button>
+          <Button asChild variant="ghost">
+            <Link to="/login">Login</Link>
           </Button>
         </Flex>
       </Flex>
@@ -29,11 +29,11 @@ export const PrivateHeader = () => {
     <Box as="header" bg="gray.100" py={4} px={8} boxShadow="sm">
       <Flex justify="space-between" align="center">
         <Heading as="h1" size="lg">
-          <RouterLink to="/product">2026 Boilerplate</RouterLink>
+          <Link to="/product">2026 Boilerplate</Link>
         </Heading>
         <Flex gap={4}>
-          <Button as={RouterLink} asChild variant="ghost">
-            <RouterLink to="/product">Product</RouterLink>
+          <Button asChild variant="ghost">
+            <Link to="/product">Product</Link>
           </Button>
           <Button asChild variant="ghost">
             <a href="/logout">Logout</a>

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -1,11 +1,11 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider as DataProvider } from 'react-redux';
-import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
-import { BrowserRouter } from 'react-router';
+import { ErrorBoundary, type FallbackProps } from 'react-error-boundary';
+import { RouterProvider } from '@tanstack/react-router';
 import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
 import { ColorModeProvider } from './components/ui/color-mode';
-import App from './App';
+import { router } from './router';
 import { store } from './components/data/store';
 import { ErrorPage } from './components/ui/error-page';
 import './styles/index.css';
@@ -20,11 +20,9 @@ const renderApp = (container: HTMLElement) => {
       <ChakraProvider value={defaultSystem}>
         <ColorModeProvider>
           <DataProvider store={store}>
-            <BrowserRouter>
-              <ErrorBoundary fallbackRender={ErrorFallback}>
-                <App />
-              </ErrorBoundary>
-            </BrowserRouter>
+            <ErrorBoundary fallbackRender={ErrorFallback}>
+              <RouterProvider router={router} />
+            </ErrorBoundary>
           </DataProvider>
         </ColorModeProvider>
       </ChakraProvider>

--- a/src/client/pages/About.tsx
+++ b/src/client/pages/About.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Container, Heading, Text, VStack, List } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router';
+import { Link } from '@tanstack/react-router';
 import { FiCheck } from 'react-icons/fi';
 import { Footer } from '../components/layout/footer';
 import { PublicHeader } from '../components/layout/header';
@@ -61,11 +61,10 @@ const About = () => {
 
           <Box>
             <Button
-              as={RouterLink}
               asChild
               colorScheme="blue"
             >
-              <a href="/">Back to Home</a>
+              <Link to="/">Back to Home</Link>
             </Button>
           </Box>
         </VStack>

--- a/src/client/pages/Home.tsx
+++ b/src/client/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Container, Heading, Text, VStack } from '@chakra-ui/react';
 import { Footer } from '../components/layout/footer';
 import { PublicHeader } from '../components/layout/header';
-import { Link as RouterLink } from 'react-router';
+import { Link } from '@tanstack/react-router';
 
 const Home = () => {
   return (
@@ -24,7 +24,7 @@ const Home = () => {
               colorScheme="blue"
               size="lg"
             >
-              <RouterLink to="/login">Login</RouterLink>
+              <Link to="/login">Login</Link>
             </Button>
           </Box>
 
@@ -34,7 +34,7 @@ const Home = () => {
               variant="outline"
               colorScheme="blue"
             >
-              <RouterLink to="/about">About This Boilerplate</RouterLink>
+              <Link to="/about">About This Boilerplate</Link>
             </Button>
           </Box>
         </VStack>

--- a/src/client/pages/NotFound.tsx
+++ b/src/client/pages/NotFound.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Container, Heading, Text, VStack } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router';
+import { Link } from '@tanstack/react-router';
 import { Footer } from '../components/layout/footer';
 import { PublicHeader } from '../components/layout/header';
 
@@ -23,12 +23,11 @@ const NotFound = () => {
 
           <Box>
             <Button
-              as={RouterLink}
               asChild
               colorScheme="blue"
               size="lg"
             >
-              <a href="/">Go Home</a>
+              <Link to="/">Go Home</Link>
             </Button>
           </Box>
         </VStack>

--- a/src/client/pages/Privacy.tsx
+++ b/src/client/pages/Privacy.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Container, Heading, Text, VStack } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router';
+import { Link } from '@tanstack/react-router';
 import { Footer } from '../components/layout/footer';
 import { PublicHeader } from '../components/layout/header';
 
@@ -85,11 +85,10 @@ const Privacy = () => {
 
           <Box>
             <Button
-              as={RouterLink}
               asChild
               colorScheme="blue"
             >
-              <a href="/">Back to Home</a>
+              <Link to="/">Back to Home</Link>
             </Button>
           </Box>
         </VStack>

--- a/src/client/pages/Terms.tsx
+++ b/src/client/pages/Terms.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Container, Heading, Text, VStack } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router';
+import { Link } from '@tanstack/react-router';
 import { Footer } from '../components/layout/footer';
 import { PublicHeader } from '../components/layout/header';
 
@@ -138,11 +138,10 @@ const Terms = () => {
 
           <Box>
             <Button
-              as={RouterLink}
               asChild
               colorScheme="blue"
             >
-              <a href="/">Back to Home</a>
+              <Link to="/">Back to Home</Link>
             </Button>
           </Box>
         </VStack>

--- a/src/client/router.tsx
+++ b/src/client/router.tsx
@@ -1,0 +1,67 @@
+import { createRouter, createRoute, createRootRoute, lazyRouteComponent } from '@tanstack/react-router';
+import App from './App';
+import Home from './pages/Home';
+
+const rootRoute = createRootRoute({
+  component: App,
+});
+
+const homeRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  component: Home,
+});
+
+const productRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/product',
+  component: lazyRouteComponent(() => import('./pages/Product')),
+});
+
+const aboutRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/about',
+  component: lazyRouteComponent(() => import('./pages/About')),
+});
+
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/login',
+  component: lazyRouteComponent(() => import('./pages/Login')),
+});
+
+const privacyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/privacy',
+  component: lazyRouteComponent(() => import('./pages/Privacy')),
+});
+
+const termsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/terms',
+  component: lazyRouteComponent(() => import('./pages/Terms')),
+});
+
+const notFoundRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '*',
+  component: lazyRouteComponent(() => import('./pages/NotFound')),
+});
+
+const routeTree = rootRoute.addChildren([
+  homeRoute,
+  productRoute,
+  aboutRoute,
+  loginRoute,
+  privacyRoute,
+  termsRoute,
+  notFoundRoute,
+]);
+
+export const router = createRouter({ routeTree });
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}


### PR DESCRIPTION
- Replace react-router with @tanstack/react-router
- Create code-based route tree in src/client/router.tsx
- Use lazyRouteComponent for code-split page loading
- Update App.tsx to use Outlet pattern
- Update main.tsx to use RouterProvider
- Update all page components and layout (header, footer) to use TanStack Router's Link component
- Remove react-router dependency

Closes #46