### PR TITLE
chore: development environment setup (AGENTS.md + lockfile fix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,10 @@ When adding or changing a feature, check all affected surfaces before opening a 
 ## Cursor Cloud specific instructions
 
 - Do not create screen recordings by default. Ask the user first and wait for explicit approval before using screen recording tools.
+- Node.js 24+ is required. The VM uses nvm; run `source ~/.nvm/nvm.sh && nvm use 24.14.1` before any npm command if not already active.
+- The `.env` file uses Node's `--env-file` flag (via `nodemon`), which does **not** strip quotes from values. Do not wrap `.env` values in quotes — they become part of the literal value.
+- The `SESSION_SECRET` validator rejects any value containing the substring `secret-here` (the `.envTemplate` default). Generate a fresh random string without that substring.
+- `npm run build` (`tsc -b && vite build`) has a pre-existing type error in `src/client/utilities/encryption.ts` related to `Uint8Array`/`BufferSource` under TypeScript 5.9. `npm run type-check` (`tsc --noEmit`) passes cleanly; use that for validation instead of `npm run build`.
+- The `accessibility/skip-link.cy.ts` Cypress test fails in headless Chrome in this VM (focus behavior difference). This is pre-existing and not caused by environment setup.
+- Before running `npm run test:e2e`, ensure the dev server is already running (`npm run dev`). Unset any `SESSION_SECRET` or `LOCAL_STORAGE_KEY` shell variables before starting the dev server to avoid env pollution — the server reads from `.env` via `--env-file`.
+- The login API endpoint is `/login/password` (form-based) or `POST /api/session` (REST-style). Both require a CSRF token from the `csrf-token` cookie.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1214,7 +1214,7 @@
     },
     "node_modules/@eslint-react/shared": {
       "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/utilities/-/shared-2.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-2.13.0.tgz",
       "integrity": "sha512-IOloCqrZ7gGBT4lFf9+0/wn7TfzU7JBRjYwTSyb9SDngsbeRrtW95ZpgUpS8/jen1wUEm6F08duAooTZ2FtsWA==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Cloud Agent sessions and fixes a pre-existing issue in the lockfile.

### Changes

1. **`AGENTS.md`** — Added detailed Cloud-specific instructions covering:
   - Node.js 24+ activation via nvm
   - `.env` quoting gotcha with Node's `--env-file` flag
   - `SESSION_SECRET` validation constraint (rejects `secret-here` substring)
   - Pre-existing `tsc -b` type error in `encryption.ts`
   - Pre-existing `skip-link.cy.ts` Cypress test failure in headless Chrome
   - CSRF token requirement for auth endpoints

2. **`package-lock.json`** — Fixed corrupted resolved URL for `@eslint-react/shared` (was incorrectly pointing to `@eslint-react/utilities/-/shared-2.13.0.tgz`), which caused `npm install` to fail with a 404.

### Verification

All commands validated:

| Check | Command | Result |
|---|---|---|
| Lint | `npm run lint` | Pass (1 warning, 0 errors) |
| Type check | `npm run type-check` | Pass |
| Dev server | `npm run dev` | Running on port 3000 |
| Login (API) | `POST /api/session` | Returns user JSON |
| Login (UI) | Browser login with test/test | Redirects to /product |
| E2E tests | `npm run test:e2e` | 9/10 pass (1 pre-existing failure) |

### Screenshots

[Home page](https://cursor.com/agents/bc-dcd8a77d-e7fe-4c72-80cf-37599bfad99b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F01-home-page.webp)
[Logged-in product page](https://cursor.com/agents/bc-dcd8a77d-e7fe-4c72-80cf-37599bfad99b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F02-logged-in-product-page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcd8a77d-e7fe-4c72-80cf-37599bfad99b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcd8a77d-e7fe-4c72-80cf-37599bfad99b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

