### PR TITLE
chore: update AGENTS.md nvm version reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ When adding or changing a feature, check all affected surfaces before opening a 
 ## Cursor Cloud specific instructions
 
 - Do not create screen recordings by default. Ask the user first and wait for explicit approval before using screen recording tools.
-- Node.js 24+ is required. The VM uses nvm; run `source ~/.nvm/nvm.sh && nvm use 24.14.1` before any npm command if not already active.
+- Node.js 24+ is required. The VM uses nvm; run `source ~/.nvm/nvm.sh && nvm use 24` before any npm command if not already active.
 - The `.env` file uses Node's `--env-file` flag (via `nodemon`), which does **not** strip quotes from values. Do not wrap `.env` values in quotes — they become part of the literal value.
 - The `SESSION_SECRET` validator rejects any value containing the substring `secret-here` (the `.envTemplate` default). Generate a fresh random string without that substring.
 - `npm run build` (`tsc -b && vite build`) has a pre-existing type error in `src/client/utilities/encryption.ts` related to `Uint8Array`/`BufferSource` under TypeScript 5.9. `npm run type-check` (`tsc --noEmit`) passes cleanly; use that for validation instead of `npm run build`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the `AGENTS.md` Cursor Cloud instructions to use `nvm use 24` instead of the pinned `nvm use 24.14.1`, making the reference resilient to minor version bumps (e.g. 24.15.0 is currently latest LTS/Krypton).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f33e01a3-5bad-4215-b6a3-5e6a47c86bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f33e01a3-5bad-4215-b6a3-5e6a47c86bb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

