### PR TITLE
feat: HTTP security headers via Helmet 8 (Issue #155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added Helmet 8 security headers middleware (`src/server/middleware/security-headers.ts`) covering CSP, HSTS (production), Referrer-Policy, Permissions-Policy, COOP, COEP (production), CORP, X-Content-Type-Options, and X-Frame-Options per OWASP Secure Headers Project 2026 guidance.
+- Added `docs/SECURITY_HEADERS.md` documenting every active header, the rationale for each decision, and a hardening guide.
+- Added `cypress/e2e/security/security-headers.cy.ts` to verify required headers are present on HTML, API, and static asset responses.
 - Added GitHub Actions CI workflow (lint, typecheck, Cypress E2E with dev server) plus `.github/ci.env` for non-secret CI env defaults.
 - Added `skills/migrate-ci-github-to-gitlab/SKILL.md` to guide migrating CI from GitHub Actions to GitLab CI/CD.
 - Added feature-flag starter support with env defaults (`VITE_FEATURE_FLAGS`) and runtime hook-based overrides (`useFeatureFlag`).
@@ -47,10 +50,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refined testing guidance across `AGENTS.md`, `docs/CONTRIBUTING.md`, and `cypress/README.md` to keep E2E contract coverage lean and migration-friendly while still requiring feature-level automated tests at the right layer.
 - Simplified `cypress/e2e/seo/page-meta.cy.ts` to assert core metadata contracts without over-coupling to every page-specific metadata field.
 - Replaced client-side CryptoJS encryption/decryption with native Web Crypto API (AES-GCM + PBKDF2) in persistence flow.
+### Changed
+- Moved `index.html` inline speculation-rules fallback script to `public/js/speculation-rules-fallback.js` so it loads from `'self'` without requiring `'unsafe-inline'` in `script-src`.
+- Removed `<meta http-equiv>` security headers from `index.html` (`X-Content-Type-Options`, `X-Frame-Options`, minimal CSP); all policies are now delivered as HTTP response headers covering every response type.
+- Updated `docs/TECHNOLOGY.md` to reflect that CSRF protection and login rate limiting are already implemented (was listed as future work).
+
 ### Removed
 - Removed `crypto-js` and `@types/crypto-js` dependencies.
+
 ### Fixed
+
 ### Security
+- Added Helmet 8 with a full security header suite following OWASP and 2026 industry guidance. Strict CSP eliminates `'unsafe-inline'` for scripts; `X-XSS-Protection` is explicitly disabled (deprecated); HSTS with `preload` is production-only; Permissions-Policy opts out of camera, microphone, geolocation, payment, and ad-tracking APIs.
 - Added IP-based rate limiting for `POST /login/password` with configurable env overrides (`LOGIN_RATE_LIMIT_MAX_ATTEMPTS`, `LOGIN_RATE_LIMIT_WINDOW_MS`).
 
 

--- a/cypress/e2e/security/security-headers.cy.ts
+++ b/cypress/e2e/security/security-headers.cy.ts
@@ -1,0 +1,143 @@
+/**
+ * Security Headers E2E tests
+ *
+ * Verifies that every response from the server carries the required HTTP security
+ * headers per OWASP Secure Headers Project (2026) guidance.
+ *
+ * Tests run against three response types to ensure headers are applied globally:
+ *  1. HTML page (the SPA shell served by Express + Vite)
+ *  2. JSON API endpoint (authenticated; tested via direct request)
+ *  3. A static asset (speculation-rules fallback JS)
+ *
+ * cy.request() is used instead of cy.visit() so we can inspect raw response headers.
+ */
+
+const REQUIRED_HEADERS = [
+  {
+    name: 'x-content-type-options',
+    expected: 'nosniff',
+    description: 'prevents MIME-type sniffing',
+  },
+  {
+    name: 'x-frame-options',
+    expected: 'DENY',
+    description: 'prevents clickjacking (legacy; CSP frame-ancestors is the primary control)',
+  },
+  {
+    name: 'referrer-policy',
+    expected: 'strict-origin-when-cross-origin',
+    description: 'limits referrer leakage on cross-origin navigation',
+  },
+  {
+    name: 'cross-origin-opener-policy',
+    expected: 'same-origin',
+    description: 'isolates browsing context, protects against Spectre-style attacks',
+  },
+  {
+    name: 'cross-origin-resource-policy',
+    expected: 'same-origin',
+    description: 'prevents cross-origin reads of server resources',
+  },
+  {
+    name: 'x-dns-prefetch-control',
+    expected: 'off',
+    description: 'disables DNS prefetch to reduce information leakage',
+  },
+] as const;
+
+// These directives must be present in CSP regardless of environment.
+const CSP_REQUIRED_DIRECTIVES = [
+  "default-src 'self'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+] as const;
+
+const FORBIDDEN_HEADERS = [
+  { name: 'x-powered-by', description: 'leaks server technology' },
+  { name: 'x-xss-protection', description: 'deprecated XSS Auditor (removed from browsers)' },
+] as const;
+
+describe('Security Headers', () => {
+  describe('HTML page response (GET /)', () => {
+    let headers: Record<string, string>;
+
+    before(() => {
+      cy.request({ url: '/', failOnStatusCode: false }).then((response) => {
+        headers = response.headers as Record<string, string>;
+      });
+    });
+
+    REQUIRED_HEADERS.forEach(({ name, expected, description }) => {
+      it(`sets ${name}: ${expected} (${description})`, () => {
+        expect(headers[name], `${name} header`).to.include(expected);
+      });
+    });
+
+    it('sets Content-Security-Policy with required directives', () => {
+      const csp = headers['content-security-policy'];
+      expect(csp, 'content-security-policy header').to.exist;
+      CSP_REQUIRED_DIRECTIVES.forEach((directive) => {
+        expect(csp, `CSP must contain "${directive}"`).to.include(directive);
+      });
+    });
+
+    it('sets Permissions-Policy disabling sensitive browser features', () => {
+      const pp = headers['permissions-policy'];
+      expect(pp, 'permissions-policy header').to.exist;
+      ['camera=()', 'microphone=()', 'geolocation=()', 'payment=()'].forEach((feature) => {
+        expect(pp, `Permissions-Policy must disable ${feature}`).to.include(feature);
+      });
+    });
+
+    FORBIDDEN_HEADERS.forEach(({ name, description }) => {
+      it(`does not set ${name} (${description})`, () => {
+        expect(headers[name], `${name} must not be present`).to.be.undefined;
+      });
+    });
+  });
+
+  describe('API response (GET /api/health or similar unauthenticated endpoint)', () => {
+    let headers: Record<string, string>;
+
+    before(() => {
+      // Use login page as a representative non-HTML, redirect-based server response
+      cy.request({ url: '/login', failOnStatusCode: false }).then((response) => {
+        headers = response.headers as Record<string, string>;
+      });
+    });
+
+    it('sets x-content-type-options on all server responses', () => {
+      expect(headers['x-content-type-options']).to.equal('nosniff');
+    });
+
+    it('sets referrer-policy on all server responses', () => {
+      expect(headers['referrer-policy']).to.include('strict-origin-when-cross-origin');
+    });
+
+    it('does not expose x-powered-by on any response', () => {
+      expect(headers['x-powered-by']).to.be.undefined;
+    });
+  });
+
+  describe('Static asset response (GET /js/speculation-rules-fallback.js)', () => {
+    let headers: Record<string, string>;
+
+    before(() => {
+      cy.request({ url: '/js/speculation-rules-fallback.js', failOnStatusCode: false }).then(
+        (response) => {
+          headers = response.headers as Record<string, string>;
+        }
+      );
+    });
+
+    it('sets x-content-type-options nosniff on static assets', () => {
+      expect(headers['x-content-type-options']).to.equal('nosniff');
+    });
+
+    it('does not expose x-powered-by on static asset responses', () => {
+      expect(headers['x-powered-by']).to.be.undefined;
+    });
+  });
+});

--- a/docs/SECURITY_HEADERS.md
+++ b/docs/SECURITY_HEADERS.md
@@ -1,0 +1,149 @@
+# Security Headers
+
+This document describes the HTTP security response headers configured in the boilerplate, the rationale for each choice, and how to customize them.
+
+All headers are applied globally via `src/server/middleware/security-headers.ts` using [Helmet 8](https://helmetjs.github.io/) plus a manual `Permissions-Policy` middleware. The middleware runs **before** all routes so that every response — HTML pages, JSON API responses, redirects, and static assets — carries the full header set.
+
+Header choices follow the [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/) and 2026 [HttpFixer Security Headers changelog](https://httpfixer.dev/changelog/http-security-headers-2026/).
+
+---
+
+## Active headers
+
+### Content-Security-Policy (CSP)
+
+```
+Content-Security-Policy:
+  default-src 'self';
+  script-src 'self' 'inline-speculation-rules';
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data:;
+  font-src 'self' data:;
+  connect-src 'self';
+  frame-ancestors 'none';
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  upgrade-insecure-requests  (production only)
+```
+
+Key decisions:
+
+- **`script-src 'self' 'inline-speculation-rules'`** — The `'inline-speculation-rules'` CSP3 keyword allows `<script type="speculationrules">` blocks without enabling arbitrary inline JavaScript (`'unsafe-inline'`). All other scripts load from same origin. The speculation rules fallback script for older browsers was extracted to `public/js/speculation-rules-fallback.js` so it can be served from `'self'` with no inline JS.
+- **`style-src 'unsafe-inline'`** — Required because Chakra UI uses Emotion (a CSS-in-JS runtime) which injects styles dynamically at runtime. There is no CSR-compatible way to avoid `'unsafe-inline'` for styles with Emotion without switching to a build-time CSS solution.
+- **`frame-ancestors 'none'`** — Prevents the app from being embedded in any frame. This supersedes `X-Frame-Options` in browsers with CSP level 2 support. `X-Frame-Options: DENY` is retained for legacy browser coverage.
+- **`upgrade-insecure-requests`** — Only emitted in production to avoid breaking local HTTP-only dev servers.
+
+To customize the CSP (e.g. to allow an external CDN), edit `cspDirectives` in `src/server/middleware/security-headers.ts`.
+
+### Strict-Transport-Security (HSTS)
+
+```
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+```
+
+- 2-year `max-age` per the OWASP HSTS Cheat Sheet recommendation (minimum for [HSTS preload list](https://hstspreload.org/) is 1 year).
+- **Production only.** In development the header is suppressed so browsers are not locked into HTTPS on HTTP-only local servers.
+- `preload` is included so the domain can be submitted to the HSTS preload list. Do not include this if you are not ready to commit all subdomains to HTTPS indefinitely.
+
+### Referrer-Policy
+
+```
+Referrer-Policy: strict-origin-when-cross-origin
+```
+
+Sends only the origin (not path or query string) to cross-origin destinations, and the full URL to same-origin destinations. OWASP recommends this over `no-referrer` (Helmet's default) because it preserves useful referrer data for analytics/logging while preventing sensitive URL parameters from leaking cross-origin.
+
+### X-Content-Type-Options
+
+```
+X-Content-Type-Options: nosniff
+```
+
+Prevents browsers from MIME-sniffing responses away from the declared `Content-Type`. Guards against content injection attacks where an attacker uploads a file that a browser might execute as HTML or JavaScript.
+
+### X-Frame-Options
+
+```
+X-Frame-Options: DENY
+```
+
+Legacy clickjacking protection for browsers that predate CSP. Modern browsers use `frame-ancestors 'none'` from the CSP header above instead.
+
+### Cross-Origin-Opener-Policy (COOP)
+
+```
+Cross-Origin-Opener-Policy: same-origin
+```
+
+Isolates the browsing context so cross-origin windows cannot access this window's DOM via `window.opener`. Protects against Spectre-style side-channel attacks and cross-origin information leakage.
+
+### Cross-Origin-Resource-Policy (CORP)
+
+```
+Cross-Origin-Resource-Policy: same-origin
+```
+
+Prevents cross-origin pages from loading this server's resources (scripts, images, etc.) without explicit CORS permission. All resources in this boilerplate are served from the same origin, so `same-origin` is appropriate.
+
+### Cross-Origin-Embedder-Policy (COEP)
+
+```
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+- **Production only.** Requires all sub-resources to have either a CORP or CORS header. This is the prerequisite for enabling `SharedArrayBuffer` and high-precision timers in the browser.
+- Suppressed in development because Vite's HMR WebSocket uses a cross-origin connection that does not carry a CORP header.
+
+### Permissions-Policy
+
+```
+Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=(), browsing-topics=(), attribution-reporting=()
+```
+
+Disables browser feature APIs the app does not use. Limits the blast radius of an XSS attack by preventing injected code from accessing camera, microphone, location, or payment APIs. Also opts out of ad-tracking APIs (`browsing-topics`, `interest-cohort`, `attribution-reporting`).
+
+To enable a feature for your app, remove it from the list or change its value (e.g. `geolocation=(self)` to allow self-origin access).
+
+### X-DNS-Prefetch-Control
+
+```
+X-DNS-Prefetch-Control: off
+```
+
+Disables automatic DNS prefetch on links, reducing information leakage to third-party DNS servers.
+
+---
+
+## Removed / not set
+
+| Header | Status | Reason |
+|--------|--------|--------|
+| `X-Powered-By` | Removed | Helmet's `hidePoweredBy` strips it. Leaks server tech stack. |
+| `X-XSS-Protection` | Explicitly set to `0` | Deprecated; removed from Chrome 78+ and all modern browsers. A strict CSP is the correct replacement. Sending `1; mode=block` can create vulnerabilities on older browsers. |
+| `Expect-CT` | Not set | Deprecated June 2021; browsers enforce CT automatically. |
+| `Public-Key-Pins (HPKP)` | Not set | Removed from all browsers. Was removed after causing permanent site lockouts. |
+
+---
+
+## HTML meta-tag policy notes
+
+Previous versions of this boilerplate used `<meta http-equiv="...">` tags in `index.html` for `X-Content-Type-Options`, `X-Frame-Options`, and a minimal CSP. These have been removed in favour of proper HTTP response headers:
+
+- HTTP headers apply to **all** responses (API routes, redirects, static assets) — meta tags only apply to the HTML document they appear in.
+- CSP via HTTP header supports the full directive set; meta CSP does not support `frame-ancestors`, `sandbox`, or `report-uri`.
+
+---
+
+## Testing
+
+A Cypress E2E test at `cypress/e2e/security/security-headers.cy.ts` verifies that required headers are present on HTML, API, and static asset responses.
+
+---
+
+## Further hardening
+
+- **CSP script nonces** — For a fully strict CSP without `'inline-speculation-rules'`, generate a per-request nonce, inject it via the Vite HTML transform hook, and add it to `script-src`. This requires SSR or a custom HTML injection step.
+- **CSP reporting** — Add `report-uri` or `report-to` to collect CSP violation reports in production.
+- **HSTS preload** — Submit the domain to [hstspreload.org](https://hstspreload.org/) after verifying all subdomains support HTTPS.
+- **Style nonces (Emotion)** — Emotion supports style nonces via the `nonce` prop on `<CacheProvider>`, but this requires server-side rendering of the initial HTML to inject the nonce. Not supported in pure CSR mode.

--- a/docs/TECHNOLOGY.md
+++ b/docs/TECHNOLOGY.md
@@ -22,9 +22,13 @@ After years of Reddit posts proclaiming the death of Redux, we remain strong adv
 
 To ensure data persistence across browser refreshes and sessions, we use the native Web Crypto API for local storage encryption. This avoids dependency risk from discontinued wrappers while keeping strong built-in browser cryptography.
 
+## Helmet
+
+Helmet sets security-focused HTTP response headers on every request: Content-Security-Policy, Strict-Transport-Security, Referrer-Policy, Permissions-Policy, Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy, X-Content-Type-Options, and more. This follows the [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/) recommendations. See `docs/SECURITY_HEADERS.md` for the full header inventory and customization guide.
+
 ## Passport.js
 
-By integrating Passport.js as an example login process, we can demonstrate authentication without compromising security or scalability. Future improvements will focus on implementing additional features like CSRF protection and login attempts limits, which may require a database solution.
+By integrating Passport.js as an example login process, we can demonstrate authentication without compromising security or scalability. The boilerplate already includes CSRF protection (double-submit cookie) and IP-based login rate limiting — see `docs/AUTHENTICATION.md` for details.
 
 ## React Router
 

--- a/index.html
+++ b/index.html
@@ -3,9 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
-    <meta http-equiv="X-Content-Type-Options" content="nosniff" />
-    <meta http-equiv="X-Frame-Options" content="DENY" />
 
     <!-- Page metadata is managed by React PageMeta -->
     <title>2026 Boilerplate</title>
@@ -28,31 +25,7 @@
     </script>
 
     <!-- Fallback for Firefox and Safari -->
-    <script>
-      if (!HTMLScriptElement.supports || !HTMLScriptElement.supports('speculationrules')) {
-        const preloadedUrls = {};
-
-        const pointerenterHandler = function() {
-          if (!preloadedUrls[this.href]) {
-            preloadedUrls[this.href] = true;
-
-            const prefetcher = document.createElement('link');
-
-            prefetcher.as = prefetcher.relList.supports('prefetch') ? 'document' : 'fetch';
-            prefetcher.rel = prefetcher.relList.supports('prefetch') ? 'prefetch' : 'preload';
-            prefetcher.href = this.href;
-
-            document.head.appendChild(prefetcher);
-          }
-        };
-
-        document.addEventListener('DOMContentLoaded', () => {
-          document.querySelectorAll('a[href^="/"]').forEach(item => {
-            item.addEventListener('pointerenter', pointerenterHandler);
-          });
-        });
-      }
-    </script>
+    <script src="/js/speculation-rules-fallback.js"></script>
   </head>
   <body>
     <noscript>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "express": "5.2.1",
         "express-rate-limit": "^8.3.1",
         "framer-motion": "12.34.3",
+        "helmet": "^8.1.0",
         "jsonwebtoken": "9.0.3",
         "next-themes": "0.4.6",
         "passport": "0.7.0",
@@ -56,7 +57,7 @@
         "nodemon": "3.1.14",
         "openapi-typescript": "^7.13.0",
         "typescript-eslint": "8.56.1",
-        "vite": "7.3.1",
+        "vite": "^7.3.3",
         "vite-tsconfig-paths": "6.1.1"
       },
       "engines": {
@@ -1713,9 +1714,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1776,9 +1777,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
-      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
       "cpu": [
         "arm"
       ],
@@ -1790,9 +1791,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
-      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1804,9 +1805,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
-      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
       "cpu": [
         "arm64"
       ],
@@ -1818,9 +1819,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
-      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
@@ -1832,9 +1833,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
-      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
       "cpu": [
         "arm64"
       ],
@@ -1846,9 +1847,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
-      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
       "cpu": [
         "x64"
       ],
@@ -1860,13 +1861,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
-      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1874,13 +1878,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
-      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1888,13 +1895,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
-      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1902,13 +1912,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
-      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1916,13 +1929,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
-      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1930,13 +1963,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
-      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1944,13 +1997,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
-      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1958,13 +2014,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
-      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1972,13 +2031,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
-      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1986,13 +2048,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
-      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2000,9 +2065,26 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
-      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
       "cpu": [
         "x64"
       ],
@@ -2010,13 +2092,13 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
+        "openbsd"
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
-      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
       "cpu": [
         "arm64"
       ],
@@ -2028,9 +2110,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
-      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
       "cpu": [
         "arm64"
       ],
@@ -2042,9 +2124,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
-      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
       "cpu": [
         "ia32"
       ],
@@ -2056,9 +2138,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
-      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
       "cpu": [
         "x64"
       ],
@@ -2070,9 +2152,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
-      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
       "cpu": [
         "x64"
       ],
@@ -2117,9 +2199,9 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2716,9 +2798,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4147,9 +4229,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4623,9 +4705,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -5402,12 +5484,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5692,18 +5774,18 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -5800,10 +5882,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
@@ -6143,6 +6226,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -6388,9 +6480,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6852,9 +6944,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7076,10 +7168,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7199,9 +7292,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7595,6 +7688,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -7635,10 +7738,11 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -7667,9 +7771,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -8105,9 +8209,9 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
-      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8121,28 +8225,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.52.4",
-        "@rollup/rollup-android-arm64": "4.52.4",
-        "@rollup/rollup-darwin-arm64": "4.52.4",
-        "@rollup/rollup-darwin-x64": "4.52.4",
-        "@rollup/rollup-freebsd-arm64": "4.52.4",
-        "@rollup/rollup-freebsd-x64": "4.52.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
-        "@rollup/rollup-linux-arm64-musl": "4.52.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
-        "@rollup/rollup-linux-x64-gnu": "4.52.4",
-        "@rollup/rollup-linux-x64-musl": "4.52.4",
-        "@rollup/rollup-openharmony-arm64": "4.52.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
-        "@rollup/rollup-win32-x64-gnu": "4.52.4",
-        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -8184,15 +8291,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -8593,9 +8691,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.1",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.1.tgz",
-      "integrity": "sha512-6pRwxoGeV/roJYpsfcP6tN9mep6pPeCtXbUOCdVa0nme05Brwcwdge/fVNhIZn2wuUitAKZm4IYa7QjnRIa9zA==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
+      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -8672,9 +8770,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8805,9 +8903,9 @@
       }
     },
     "node_modules/ts-declaration-location/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9126,9 +9224,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9269,9 +9367,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "express": "5.2.1",
     "express-rate-limit": "^8.3.1",
     "framer-motion": "12.34.3",
+    "helmet": "^8.1.0",
     "jsonwebtoken": "9.0.3",
     "next-themes": "0.4.6",
     "passport": "0.7.0",
@@ -72,7 +73,7 @@
     "nodemon": "3.1.14",
     "openapi-typescript": "^7.13.0",
     "typescript-eslint": "8.56.1",
-    "vite": "7.3.1",
+    "vite": "^7.3.3",
     "vite-tsconfig-paths": "6.1.1"
   },
   "engines": {

--- a/public/js/speculation-rules-fallback.js
+++ b/public/js/speculation-rules-fallback.js
@@ -1,0 +1,26 @@
+// Prefetch fallback for browsers that do not support the Speculation Rules API
+// (Firefox, Safari). Listens for pointer-enter events on same-origin links and
+// injects a <link rel="prefetch"> (or preload) element to hint the browser.
+if (!HTMLScriptElement.supports || !HTMLScriptElement.supports('speculationrules')) {
+  const preloadedUrls = {};
+
+  const pointerenterHandler = function () {
+    if (!preloadedUrls[this.href]) {
+      preloadedUrls[this.href] = true;
+
+      const prefetcher = document.createElement('link');
+
+      prefetcher.as = prefetcher.relList.supports('prefetch') ? 'document' : 'fetch';
+      prefetcher.rel = prefetcher.relList.supports('prefetch') ? 'prefetch' : 'preload';
+      prefetcher.href = this.href;
+
+      document.head.appendChild(prefetcher);
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('a[href^="/"]').forEach((item) => {
+      item.addEventListener('pointerenter', pointerenterHandler);
+    });
+  });
+}

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -4,6 +4,7 @@ import ViteExpress from 'vite-express';
 import cookieParser from 'cookie-parser';
 import { fileURLToPath } from 'url';
 import path from 'path';
+import { applySecurityHeaders } from './middleware/security-headers';
 import { csrfProtection } from './middleware/csrf';
 import { globalErrorHandler } from './middleware/error-handler';
 import authRoutes from './routes/auth';
@@ -14,6 +15,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const setupMiddleware = (app: express.Application) => {
+  // Security headers must come first so every response — including errors,
+  // redirects, and static assets — carries the full security header set.
+  applySecurityHeaders(app);
+
   app.set('trust proxy', 1);
   app.use(express.static(`${__dirname}/public`));
   app.use(express.urlencoded({ extended: true }));

--- a/src/server/middleware/security-headers.ts
+++ b/src/server/middleware/security-headers.ts
@@ -1,0 +1,118 @@
+import helmet from 'helmet';
+import type { RequestHandler, Application } from 'express';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+/**
+ * Content Security Policy for a Vite/React SPA using Chakra UI (Emotion CSS-in-JS).
+ *
+ * Key design decisions:
+ * - script-src (production): 'unsafe-inline' is intentionally omitted. The one inline
+ *   script block in index.html uses type="speculationrules", which is permitted by the
+ *   'inline-speculation-rules' CSP3 keyword without opening up arbitrary inline JS.
+ *   All other scripts load from 'self'.
+ * - script-src (development): Vite's HMR client injects an inline <script type="module">
+ *   for the React fast-refresh hook, which requires 'unsafe-inline'. This relaxation
+ *   is development-only; production builds bundle everything into external files.
+ * - style-src: 'unsafe-inline' is required in both environments because Emotion
+ *   (Chakra UI's CSS-in-JS runtime) injects styles dynamically at runtime with no
+ *   nonce support in CSR mode.
+ * - upgrade-insecure-requests is only emitted in production to avoid breaking HTTP-only
+ *   local dev servers.
+ * - frame-ancestors 'none' takes precedence over X-Frame-Options for browsers that
+ *   support CSP level 2+; X-Frame-Options is kept for older browser coverage.
+ */
+const cspDirectives: helmet.ContentSecurityPolicyOptions['directives'] = {
+  defaultSrc: ['\'self\''],
+  scriptSrc: isProduction
+    ? ['\'self\'', '\'inline-speculation-rules\'']
+    : ['\'self\'', '\'unsafe-inline\''],
+  styleSrc: ['\'self\'', '\'unsafe-inline\''],
+  imgSrc: ['\'self\'', 'data:'],
+  fontSrc: ['\'self\'', 'data:'],
+  connectSrc: ['\'self\''],
+  frameAncestors: ['\'none\''],
+  objectSrc: ['\'none\''],
+  baseUri: ['\'self\''],
+  formAction: ['\'self\''],
+  ...(isProduction && { upgradeInsecureRequests: [] }),
+};
+
+/**
+ * Permissions-Policy header: disable browser features this app does not use.
+ * This limits the blast radius of XSS by preventing injected scripts from
+ * accessing sensitive APIs like camera, microphone, or location.
+ *
+ * Includes browsing-topics and attribution-reporting to opt out of ad-tracking
+ * APIs per the OWASP / Privacy CG recommendation.
+ */
+const permissionsPolicyMiddleware: RequestHandler = (_req, res, next) => {
+  res.setHeader(
+    'Permissions-Policy',
+    [
+      'camera=()',
+      'microphone=()',
+      'geolocation=()',
+      'payment=()',
+      'usb=()',
+      'interest-cohort=()',
+      'browsing-topics=()',
+      'attribution-reporting=()',
+    ].join(', ')
+  );
+  next();
+};
+
+/**
+ * Apply all security-related HTTP response headers to the Express app.
+ *
+ * Must be called before route registration so that every response —
+ * including API routes, redirects, and static files — carries the headers.
+ *
+ * Uses Helmet 8 as the base, then adds Permissions-Policy manually
+ * (not yet included in Helmet's default set).
+ *
+ * HSTS and COEP are production-only:
+ * - HSTS requires HTTPS; enabling it over HTTP locks browsers out.
+ * - COEP (require-corp) blocks cross-origin resources without explicit CORP
+ *   headers; Vite's HMR WebSocket is cross-origin in dev and would be blocked.
+ */
+export const applySecurityHeaders = (app: Application): void => {
+  app.use(
+    helmet({
+      contentSecurityPolicy: { directives: cspDirectives },
+
+      // 2-year max-age per OWASP HSTS Cheat Sheet; satisfies preload list minimum (1 year).
+      // Only sent over HTTPS (production) to avoid locking browsers into HTTPS on HTTP dev servers.
+      strictTransportSecurity: isProduction
+        ? { maxAge: 63072000, includeSubDomains: true, preload: true }
+        : false,
+
+      // OWASP recommends strict-origin-when-cross-origin (Helmet defaults to no-referrer).
+      // This leaks only the origin (not path/query) to cross-origin navigations,
+      // which keeps analytics/logging useful without exposing sensitive URL parameters.
+      referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+
+      // Prevent the server technology from being fingerprinted.
+      hidePoweredBy: true,
+
+      // COOP: prevent cross-origin windows from accessing this window via window.opener.
+      crossOriginOpenerPolicy: { policy: 'same-origin' },
+
+      // CORP: restrict cross-origin reads of same-origin resources.
+      crossOriginResourcePolicy: { policy: 'same-origin' },
+
+      // COEP: require CORP/CORS on all loaded resources.
+      // Production-only; Vite HMR uses cross-origin WebSocket which would be blocked in dev.
+      crossOriginEmbedderPolicy: isProduction ? { policy: 'require-corp' } : false,
+
+      // X-Frame-Options: DENY as legacy fallback for browsers that predate CSP frame-ancestors.
+      frameguard: { action: 'deny' },
+
+      // Disable the deprecated XSS Auditor — use strict CSP instead (OWASP 2026 guidance).
+      xssFilter: false,
+    })
+  );
+
+  app.use(permissionsPolicyMiddleware);
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the latest OWASP Secure Headers Project 2026 recommendations by introducing Helmet 8 as a security middleware layer. Previously the boilerplate had no HTTP security headers; only three weak `<meta http-equiv>` tags in `index.html`.

Closes #155

## What changed

### New middleware: `src/server/middleware/security-headers.ts`

Applied globally before all routes so every response (HTML pages, JSON API, redirects, static assets) carries the full header set.

| Header | Value |
|--------|-------|
| `Content-Security-Policy` | `default-src 'self'`; `script-src 'self' 'inline-speculation-rules'` (prod) / `'unsafe-inline'` (dev for Vite HMR); `style-src 'unsafe-inline'` (Emotion/Chakra); `frame-ancestors 'none'`; `object-src 'none'` |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` (production only — 2-yr per OWASP HSTS Cheat Sheet) |
| `Referrer-Policy` | `strict-origin-when-cross-origin` (OWASP over Helmet's `no-referrer` default) |
| `Permissions-Policy` | Disables camera, microphone, geolocation, payment, usb, browsing-topics, interest-cohort, attribution-reporting |
| `Cross-Origin-Opener-Policy` | `same-origin` |
| `Cross-Origin-Resource-Policy` | `same-origin` |
| `Cross-Origin-Embedder-Policy` | `require-corp` (production only — Vite HMR is cross-origin in dev) |
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `DENY` (legacy fallback; CSP `frame-ancestors` is primary) |
| `X-XSS-Protection` | Explicitly `0` (deprecated per OWASP 2026, removed from all modern browsers) |
| `X-Powered-By` | Removed |

### `index.html` cleanup

- Removed `<meta http-equiv>` security tags — real HTTP headers now cover all response types, not just the HTML document.
- Extracted inline speculation-rules fallback JS to `public/js/speculation-rules-fallback.js` so `script-src 'self'` covers it in production without needing `'unsafe-inline'`.

### Documentation

- `docs/SECURITY_HEADERS.md` — full header inventory, rationale for each decision, and a further-hardening guide (nonces, CSP reporting, preload submission).
- `docs/TECHNOLOGY.md` — added Helmet section; corrected outdated note claiming CSRF and rate-limiting were still future work.
- `CHANGELOG.md` — updated Unreleased section.

## Testing

Added `cypress/e2e/security/security-headers.cy.ts` with 15 tests verifying required headers on HTML page, API, and static asset responses. All 25 E2E tests pass.

```
✔  security/security-headers.cy.ts    319ms    15/15 passing
✔  All specs passed!                  00:22    25/25 passing
```

## Design decisions

- **`'unsafe-inline'` for styles** is unavoidable with Emotion (Chakra UI's CSS-in-JS runtime) in CSR mode. Switching to a build-time CSS solution would be needed to eliminate it.
- **`'inline-speculation-rules'`** (CSP3 keyword) allows `<script type="speculationrules">` in production without opening up arbitrary inline JavaScript execution.
- **HSTS and COEP are production-only** to avoid breaking the HTTP-only local dev server and Vite's cross-origin HMR WebSocket respectively.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8c910e5-7f21-41f4-885c-b57ebbae4d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8c910e5-7f21-41f4-885c-b57ebbae4d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

