### PR TITLE
fix: remove SESSION_SECRET startup validation (Issue #159)

### DIFF
--- a/.envTemplate
+++ b/.envTemplate
@@ -1,16 +1,14 @@
 # Environment Variables Template
-# Copy this file to .env and replace the placeholder values with your actual values
+# Copy this file to .env to get started: cp .envTemplate .env
+# Default values work for local development. Change SESSION_SECRET and LOCAL_STORAGE_KEY before deploying to production.
 
 # Local Storage Encryption Key
 # Used to encrypt data stored in the browser's localStorage
-# Replace with a strong, random string
-LOCAL_STORAGE_KEY="your-secret-key-here"
+LOCAL_STORAGE_KEY=local-dev-storage-key
 
 # JWT / Session Secret
 # Used to sign JWT authentication tokens
-# CRITICAL: Replace with a strong, random string (e.g. output of `openssl rand -base64 32`)
-# The server will refuse to start if this is left as the default value
-SESSION_SECRET="your-session-secret-here"
+SESSION_SECRET=local-dev-session-secret
 
 # Node Environment
 # Options: development, production
@@ -40,4 +38,3 @@ NODE_ENV=development
 # SUPABASE_URL=
 # SUPABASE_ANON_KEY=
 # DATABASE_URL=
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ When adding or changing a feature, check all affected surfaces before opening a 
 - Do not create screen recordings by default. Ask the user first and wait for explicit approval before using screen recording tools.
 - Node.js 24+ is required. The VM uses nvm; run `source ~/.nvm/nvm.sh && nvm use 24` before any npm command if not already active.
 - The `.env` file uses Node's `--env-file` flag (via `nodemon`), which does **not** strip quotes from values. Do not wrap `.env` values in quotes — they become part of the literal value.
-- The `SESSION_SECRET` validator rejects any value containing the substring `secret-here` (the `.envTemplate` default). Generate a fresh random string without that substring.
+- `cp .envTemplate .env` is sufficient to start the server; the template ships with working local-dev defaults for `SESSION_SECRET` and `LOCAL_STORAGE_KEY`.
 - `npm run build` (`tsc -b && vite build`) has a pre-existing type error in `src/client/utilities/encryption.ts` related to `Uint8Array`/`BufferSource` under TypeScript 5.9. `npm run type-check` (`tsc --noEmit`) passes cleanly; use that for validation instead of `npm run build`.
 - The `accessibility/skip-link.cy.ts` Cypress test fails in headless Chrome in this VM (focus behavior difference). This is pre-existing and not caused by environment setup.
 - Before running `npm run test:e2e`, ensure the dev server is already running (`npm run dev`). Unset any `SESSION_SECRET` or `LOCAL_STORAGE_KEY` shell variables before starting the dev server to avoid env pollution — the server reads from `.env` via `--env-file`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed `SESSION_SECRET` startup validation: the server no longer rejects short or template-like values. The `.envTemplate` now ships with working local-dev defaults (`local-dev-session-secret`, `local-dev-storage-key`) so `cp .envTemplate .env && npm run dev` works without any additional setup. Use strong random values in production.
+
 ### Added
 
 - Added Helmet 8 security headers middleware (`src/server/middleware/security-headers.ts`) covering CSP, HSTS (production), Referrer-Policy, Permissions-Policy, COOP, COEP (production), CORP, X-Content-Type-Options, and X-Frame-Options per OWASP Secure Headers Project 2026 guidance.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Use this workflow when you want to turn this repository into your own product in
 
 ### Development Setup
 
-1. Copy the env template: `cp .envTemplate .env` — then set `LOCAL_STORAGE_KEY` and `SESSION_SECRET`. Generate a session secret with: `openssl rand -base64 32`
+1. Copy the env template: `cp .envTemplate .env` — default values work for local development; set strong random values for `SESSION_SECRET` and `LOCAL_STORAGE_KEY` before deploying to production
 2. Run `npm install`
 3. Run `npm run dev`
 4. Login with username `test` and password `test`

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -45,8 +45,7 @@ Optional env overrides in `.env`:
 - Signing + verification: `src/server/services/jwt.ts`
 - Algorithm: `HS256`
 - Expiration: `24h`
-- Secret source: `SESSION_SECRET`
-- Startup safety: server throws if `SESSION_SECRET` is weak or still template-like
+- Secret source: `SESSION_SECRET` (defaults to `local-dev-session-secret` from `.envTemplate`; use a strong random value in production)
 
 ## Local auth profile (default)
 

--- a/skills/migrate-ci-github-to-gitlab/SKILL.md
+++ b/skills/migrate-ci-github-to-gitlab/SKILL.md
@@ -54,8 +54,8 @@ Use this skill when a task asks to move continuous integration off GitHub-specif
 
 ### 2) `ci/ci.env` (when migrating off `.github/ci.env`)
 
-- Move (not duplicate) the existing file if present; keep the same variable names and **long** `SESSION_SECRET` requirement (JWT service rejects short secrets).
-- If the file did not exist, create it with the same contract as `.envTemplate` but with **safe CI-only placeholders** (length ≥ 16 for `SESSION_SECRET`, not the literal `[REDACTED]` from the template).
+- Move (not duplicate) the existing file if present; keep the same variable names.
+- If the file did not exist, create it with the same contract as `.envTemplate` (any non-empty value for `SESSION_SECRET` and `LOCAL_STORAGE_KEY` is accepted; the template's defaults work as CI placeholders).
 
 ## Files to remove or stop maintaining
 

--- a/src/server/services/jwt.ts
+++ b/src/server/services/jwt.ts
@@ -1,20 +1,6 @@
 import jwt from 'jsonwebtoken';
 
-const MIN_SECRET_LENGTH = 16;
-
-const getJwtSecret = (): string => {
-  const secret = process.env.SESSION_SECRET;
-  if (!secret || secret.length < MIN_SECRET_LENGTH || secret.includes('secret-here')) {
-    throw new Error(
-      'SESSION_SECRET is not configured securely. Set it in your .env file to a strong, random string '
-      + `at least ${String(MIN_SECRET_LENGTH)} characters long (e.g. output of \`openssl rand -base64 32\`). `
-      + 'Do NOT use the default value from .envTemplate.'
-    );
-  }
-  return secret;
-};
-
-const JWT_SECRET = getJwtSecret();
+const JWT_SECRET = process.env.SESSION_SECRET ?? '';
 const JWT_ALGORITHM = 'HS256' as const;
 const JWT_EXPIRY = '24h';
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the `SESSION_SECRET` startup check that blocked the server from starting when the value was shorter than 16 characters or contained the substring `secret-here`. This caused unnecessary friction on first clone — developers had to manually generate and paste a secret before they could even run `npm run dev`.

Closes #159

## What changed

### `src/server/services/jwt.ts`

Removed `getJwtSecret()` and its length/substring validation. `JWT_SECRET` is now read directly from the environment variable with an empty-string fallback.

**Before:**
```ts
const MIN_SECRET_LENGTH = 16;
const getJwtSecret = (): string => {
  const secret = process.env.SESSION_SECRET;
  if (!secret || secret.length < MIN_SECRET_LENGTH || secret.includes('secret-here')) {
    throw new Error('SESSION_SECRET is not configured securely...');
  }
  return secret;
};
const JWT_SECRET = getJwtSecret();
```

**After:**
```ts
const JWT_SECRET = process.env.SESSION_SECRET ?? '';
```

### `.envTemplate`

Replaced placeholder values that required manual replacement with working local-dev defaults. `cp .envTemplate .env && npm run dev` now starts the server immediately with no additional setup.

```
SESSION_SECRET=local-dev-session-secret
LOCAL_STORAGE_KEY=local-dev-storage-key
```

The file header still notes that these should be replaced with strong random values before deploying to production.

### Docs updated

- `README.md` — setup step 1 simplified
- `docs/AUTHENTICATION.md` — removed "server throws" note; added production guidance inline
- `AGENTS.md` — replaced validator warning with zero-friction setup note
- `skills/migrate-ci-github-to-gitlab/SKILL.md` — removed length ≥ 16 requirement for CI env files

## Testing

All 25 E2E tests pass with the template defaults (`local-dev-session-secret`):

```
✔  All specs passed!    00:22    25/25 passing
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8c910e5-7f21-41f4-885c-b57ebbae4d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8c910e5-7f21-41f4-885c-b57ebbae4d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

