### PR TITLE
feat: add Vitest unit test suite (Issue #163)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,10 @@ When adding or changing a feature, check all affected surfaces before opening a 
 ## Testing
 
 - Login credentials: username `test`, password `test`
-- E2E tests are in `cypress/e2e/` and require the dev server to be running
+- Unit tests use Vitest: `npm run test:unit` (no dev server needed). Test files live next to their source as `*.test.ts`. Use `node` environment for `src/server/**` and `happy-dom` for `src/client/**` (configured in `vitest.config.ts`).
+- E2E tests are in `cypress/e2e/` and require the dev server to be running.
 - The Cypress suite is intentionally compact and contract-focused for easier migration to other test frameworks.
-- Before committing: `npm run test`
+- Before committing: `npm run test` (runs lint → type-check → unit → E2E)
 
 ## Cursor Cloud specific instructions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added Vitest 4 unit test suite (`npm run test:unit`) with 69 tests across 8 files covering server config (`api-error`, `redirects`, `auth-profile`), server services (`hashPassword`, JWT sign/verify), server middleware (`globalErrorHandler`), and client utilities (`parseFeatureFlags`/`isFeatureEnabled`, `formatDate`/`formatNumber`/`formatCurrency`).
+- Added `vitest.config.ts` with per-directory environment mapping: `node` for `src/server/**` tests, `happy-dom` for `src/client/**` tests.
+- `npm run test` now runs `lint → type-check → test:unit → test:e2e`.
+
 ### Changed
 
 - Removed `SESSION_SECRET` startup validation: the server no longer rejects short or template-like values. The `.envTemplate` now ships with working local-dev defaults (`local-dev-session-secret`, `local-dev-storage-key`) so `cp .envTemplate .env && npm run dev` works without any additional setup. Use strong random values in production.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you want deep implementation details (architecture, auth internals, reducer p
 - **i18n:** react-intl, locales (en, ar, fr, zh), RTL for Arabic, language switcher, English fallback—[use it or ignore it](docs/I18N.md); when you need translation, it's ready
 - **UX and polish:** Page transitions (`<PageTransition>`), animated buttons (Framer Motion), scroll-to-top on route change, light/dark mode
 - **Resilience:** Error boundaries, centralized client error handler, server error-handler middleware, Suspense boundaries
-- **Developer experience:** Cypress E2E, ESLint (custom config), type-check script, `npm run test` for full pre-commit/CI (lint + type-check + E2E)
+- **Developer experience:** Vitest unit tests (`npm run test:unit`), Cypress E2E, ESLint (custom config), type-check script, `npm run test` for full pre-commit/CI (lint + type-check + unit + E2E)
 
 ## Getting Started
 
@@ -42,6 +42,7 @@ Use this workflow when you want to turn this repository into your own product in
 | Goal | Command |
 |---|---|
 | Start coding | `npm run dev` |
+| Run unit tests | `npm run test:unit` |
 | Validate before commit | `npm run test` |
 | Build for production | `npm run build` |
 | Preview production build | `npm run preview` |
@@ -85,7 +86,7 @@ For script implementation details (like i18n validation), see [scripts/README.md
 - Node.js >= 24.13.1, npm >= 11.10.1
 - `.env` file (copy from `.envTemplate`)
 
-E2E tests require the dev server running and a supported browser. See [cypress/README.md](cypress/README.md).
+Unit tests run with `npm run test:unit` and require no dev server. E2E tests require the dev server running and a supported browser. See [cypress/README.md](cypress/README.md).
 
 ## GitHub Actions CI
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -71,10 +71,19 @@ Runs ESLint and automatically fixes issues where possible.
 ## Testing
 
 ### `npm run test`
-Runs the full validation suite: lint, type-check, and E2E tests.
-- Equivalent to: `npm run lint && npm run type-check && npm run test:e2e`
+Runs the full validation suite: lint, type-check, unit tests, and E2E tests.
+- Equivalent to: `npm run lint && npm run type-check && npm run test:unit && npm run test:e2e`
 
 **When to use:** Before committing, in CI/CD, when preparing for deployment
+
+### `npm run test:unit`
+Runs Vitest unit tests in watch-less run mode.
+- No dev server required
+- Test files live next to their source as `*.test.ts`
+- Server tests run in a `node` environment; client tests run in `happy-dom`
+- Configuration in `vitest.config.ts`
+
+**When to use:** After changing a service, utility, or middleware to verify logic in isolation; fast feedback loop during development
 
 ### `npm run test:e2e`
 Runs Cypress end-to-end tests in headless mode.
@@ -149,6 +158,10 @@ npm start
 - npm 11.10.1 or higher
 - `.env` file with required environment variables
 
+### Unit Tests
+- No dev server required
+- Node.js 24+ (same as dev)
+
 ### E2E Tests
 - Development server running (`npm run dev`)
 - Chrome, Firefox, or Edge browser installed
@@ -173,6 +186,11 @@ Scripts use environment variables from `.env`:
 - Run `npm run type-check` to find TypeScript errors
 - Run `npm run lint` to find linting issues
 - Check console for specific error messages
+
+### `npm run test:unit` fails
+- Check the failing test file and assertion — most unit tests are pure and do not need a running server
+- If a server-side module fails to import, confirm `SESSION_SECRET` is set in `vitest.config.ts` `test.env`
+- Run `npm run type-check` if you see TypeScript-related import errors
 
 ### `npm run test:e2e` fails
 - Ensure dev server is running (`npm run dev`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,11 +54,13 @@
         "eslint-plugin-react-refresh": "0.5.2",
         "eslint-plugin-react-x": "2.13.0",
         "globals": "17.3.0",
+        "happy-dom": "^20.9.0",
         "nodemon": "3.1.14",
         "openapi-typescript": "^7.13.0",
         "typescript-eslint": "8.56.1",
         "vite": "^7.3.3",
-        "vite-tsconfig-paths": "6.1.1"
+        "vite-tsconfig-paths": "6.1.1",
+        "vitest": "^4.1.6"
       },
       "engines": {
         "node": ">=24.13.1",
@@ -2166,9 +2168,9 @@
       ]
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -2272,6 +2274,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2291,6 +2304,13 @@
       "peerDependencies": {
         "@types/express": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ejs": {
       "version": "3.1.5",
@@ -2512,6 +2532,23 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -2938,6 +2975,119 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@zag-js/accordion": {
@@ -4040,6 +4190,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -4409,6 +4569,16 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5004,6 +5174,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -5030,6 +5213,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -5378,6 +5568,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5438,6 +5638,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -6149,6 +6359,24 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -7077,6 +7305,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7416,6 +7654,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7706,6 +7955,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pause": {
       "version": "0.0.1",
@@ -8514,6 +8770,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -8606,6 +8869,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -8614,6 +8884,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-ts": {
       "version": "2.3.1",
@@ -8734,6 +9011,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8780,6 +9074,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -9379,6 +9683,119 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9393,6 +9810,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -9427,6 +9861,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "preview": "vite preview",
     "start": "NODE_ENV=production tsx src/server/main.ts",
     "type-check": "tsc --noEmit",
-    "test": "npm run lint && npm run type-check && npm run test:e2e",
+    "test": "npm run lint && npm run type-check && npm run test:unit && npm run test:e2e",
+    "test:unit": "vitest run",
     "test:e2e": "cypress run",
     "test:e2e:open": "cypress open"
   },
@@ -70,11 +71,13 @@
     "eslint-plugin-react-refresh": "0.5.2",
     "eslint-plugin-react-x": "2.13.0",
     "globals": "17.3.0",
+    "happy-dom": "^20.9.0",
     "nodemon": "3.1.14",
     "openapi-typescript": "^7.13.0",
     "typescript-eslint": "8.56.1",
     "vite": "^7.3.3",
-    "vite-tsconfig-paths": "6.1.1"
+    "vite-tsconfig-paths": "6.1.1",
+    "vitest": "^4.1.6"
   },
   "engines": {
     "node": ">=24.13.1",

--- a/src/client/utilities/feature-flags.test.ts
+++ b/src/client/utilities/feature-flags.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { parseFeatureFlags, isFeatureEnabled } from './feature-flags';
+
+describe('parseFeatureFlags', () => {
+  it('returns an empty object for undefined input', () => {
+    expect(parseFeatureFlags(undefined)).toEqual({});
+  });
+
+  it('returns an empty object for an empty string', () => {
+    expect(parseFeatureFlags('')).toEqual({});
+  });
+
+  it('parses a single true flag', () => {
+    expect(parseFeatureFlags('featureA=true')).toEqual({ featureA: true });
+  });
+
+  it('parses a single false flag', () => {
+    expect(parseFeatureFlags('featureA=false')).toEqual({ featureA: false });
+  });
+
+  it('parses multiple flags separated by commas', () => {
+    const result = parseFeatureFlags('featureA=true,featureB=false,featureC=true');
+    expect(result).toEqual({ featureA: true, featureB: false, featureC: true });
+  });
+
+  it('treats "1" as true', () => {
+    expect(parseFeatureFlags('flag=1')).toEqual({ flag: true });
+  });
+
+  it('treats "on" as true', () => {
+    expect(parseFeatureFlags('flag=on')).toEqual({ flag: true });
+  });
+
+  it('treats "yes" as true', () => {
+    expect(parseFeatureFlags('flag=yes')).toEqual({ flag: true });
+  });
+
+  it('treats "0" as false', () => {
+    expect(parseFeatureFlags('flag=0')).toEqual({ flag: false });
+  });
+
+  it('treats "off" as false', () => {
+    expect(parseFeatureFlags('flag=off')).toEqual({ flag: false });
+  });
+
+  it('treats "no" as false', () => {
+    expect(parseFeatureFlags('flag=no')).toEqual({ flag: false });
+  });
+
+  it('is case-insensitive for truthy values', () => {
+    expect(parseFeatureFlags('flag=TRUE')).toEqual({ flag: true });
+    expect(parseFeatureFlags('flag=Yes')).toEqual({ flag: true });
+  });
+
+  it('trims whitespace around flag entries', () => {
+    expect(parseFeatureFlags('  featureA = true  ')).toEqual({ featureA: true });
+  });
+
+  it('skips entries with no flag name', () => {
+    expect(parseFeatureFlags(',featureA=true,')).toEqual({ featureA: true });
+  });
+
+  it('defaults missing value to false', () => {
+    // "featureA" with no "=value" part → defaults to false
+    const result = parseFeatureFlags('featureA');
+    expect(result.featureA).toBe(false);
+  });
+});
+
+describe('isFeatureEnabled', () => {
+  it('returns true when the runtime override is true', () => {
+    expect(isFeatureEnabled('myFlag', { myFlag: true })).toBe(true);
+  });
+
+  it('returns false when the runtime override is false', () => {
+    expect(isFeatureEnabled('myFlag', { myFlag: false })).toBe(false);
+  });
+
+  it('runtime override takes precedence over the env-based value', () => {
+    // Even if ENV_FEATURE_FLAGS has a different value, the override wins.
+    expect(isFeatureEnabled('myFlag', { myFlag: false })).toBe(false);
+  });
+
+  it('returns false for an unknown flag with no override', () => {
+    expect(isFeatureEnabled('nonExistentFlag', {})).toBe(false);
+  });
+});

--- a/src/client/utilities/formatting.test.ts
+++ b/src/client/utilities/formatting.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate, formatNumber, formatCurrency } from './formatting';
+
+const LOCALE = 'en-US';
+const FIXED_DATE = new Date('2026-05-13T12:00:00Z');
+
+describe('formatDate', () => {
+  it('returns a human-readable date string', () => {
+    const result = formatDate(FIXED_DATE, LOCALE);
+    // "May 13, 2026" in en-US
+    expect(result).toBe('May 13, 2026');
+  });
+
+  it('overrides the default month style via options', () => {
+    // formatDate spreads defaults (year, month: long, day) then applies options.
+    // Providing month: 'short' overrides month but keeps the day default → "May 13, 2026".
+    const result = formatDate(FIXED_DATE, LOCALE, { month: 'short' });
+    expect(result).toBe('May 13, 2026');
+  });
+
+  it('handles a different locale', () => {
+    // In fr-FR the month name is localised — just confirm it differs from en-US
+    const enResult = formatDate(FIXED_DATE, LOCALE);
+    const frResult = formatDate(FIXED_DATE, 'fr-FR');
+    expect(frResult).not.toBe(enResult);
+  });
+});
+
+describe('formatNumber', () => {
+  it('formats an integer with no options', () => {
+    expect(formatNumber(1234567, LOCALE)).toBe('1,234,567');
+  });
+
+  it('formats a decimal number', () => {
+    expect(formatNumber(3.14159, LOCALE, { maximumFractionDigits: 2 })).toBe('3.14');
+  });
+
+  it('formats zero', () => {
+    expect(formatNumber(0, LOCALE)).toBe('0');
+  });
+
+  it('formats negative numbers', () => {
+    expect(formatNumber(-42, LOCALE)).toBe('-42');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('formats a USD amount in en-US', () => {
+    expect(formatCurrency(9.99, 'USD', LOCALE)).toBe('$9.99');
+  });
+
+  it('formats a EUR amount', () => {
+    const result = formatCurrency(100, 'EUR', LOCALE);
+    // en-US formats EUR as "€100.00" or "EUR 100.00" depending on runtime;
+    // just confirm the numeric value and currency code are present.
+    expect(result).toContain('100');
+    expect(result.toLowerCase()).toMatch(/eur|€/);
+  });
+
+  it('defaults to USD when no currency argument is provided', () => {
+    const withDefault = formatCurrency(50, undefined, LOCALE);
+    const withExplicit = formatCurrency(50, 'USD', LOCALE);
+    expect(withDefault).toBe(withExplicit);
+  });
+});

--- a/src/server/config/api-error.test.ts
+++ b/src/server/config/api-error.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { createApiError, API_ERRORS } from './api-error';
+
+describe('createApiError', () => {
+  it('returns an object with status, code, and message', () => {
+    const error = createApiError(404, 'NOT_FOUND', 'Thing not found');
+    expect(error).toEqual({ status: 404, code: 'NOT_FOUND', message: 'Thing not found' });
+  });
+});
+
+describe('API_ERRORS', () => {
+  describe('unauthorized', () => {
+    it('returns 401 with UNAUTHORIZED code', () => {
+      const err = API_ERRORS.unauthorized();
+      expect(err.status).toBe(401);
+      expect(err.code).toBe('UNAUTHORIZED');
+      expect(err.message).toBeTruthy();
+    });
+  });
+
+  describe('forbidden', () => {
+    it('uses the default message when none is given', () => {
+      const err = API_ERRORS.forbidden();
+      expect(err.status).toBe(403);
+      expect(err.code).toBe('FORBIDDEN');
+      expect(err.message).toBe('Access denied');
+    });
+
+    it('uses the supplied custom message', () => {
+      const err = API_ERRORS.forbidden('CSRF token validation failed');
+      expect(err.message).toBe('CSRF token validation failed');
+    });
+  });
+
+  describe('notFound', () => {
+    it('interpolates the default resource name', () => {
+      const err = API_ERRORS.notFound();
+      expect(err.status).toBe(404);
+      expect(err.message).toContain('Resource');
+    });
+
+    it('interpolates a custom resource name', () => {
+      const err = API_ERRORS.notFound('User');
+      expect(err.message).toBe('User not found');
+    });
+  });
+
+  describe('validation', () => {
+    it('returns 422 with VALIDATION_ERROR code', () => {
+      const err = API_ERRORS.validation('Email is invalid');
+      expect(err.status).toBe(422);
+      expect(err.code).toBe('VALIDATION_ERROR');
+      expect(err.message).toBe('Email is invalid');
+    });
+  });
+
+  describe('internal', () => {
+    it('returns 500 with INTERNAL_ERROR code', () => {
+      const err = API_ERRORS.internal();
+      expect(err.status).toBe(500);
+      expect(err.code).toBe('INTERNAL_ERROR');
+    });
+
+    it('uses a custom message when provided', () => {
+      const err = API_ERRORS.internal('Database unavailable');
+      expect(err.message).toBe('Database unavailable');
+    });
+  });
+});

--- a/src/server/config/auth-profile.test.ts
+++ b/src/server/config/auth-profile.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { getAuthProfile, isExternalAuthProfile, AUTH_PROFILES } from './auth-profile';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('getAuthProfile', () => {
+  it('returns "local" when AUTH_PROFILE is not set', () => {
+    vi.stubEnv('AUTH_PROFILE', '');
+    expect(getAuthProfile()).toBe(AUTH_PROFILES.LOCAL);
+  });
+
+  it('returns "local" for AUTH_PROFILE=local', () => {
+    vi.stubEnv('AUTH_PROFILE', 'local');
+    expect(getAuthProfile()).toBe(AUTH_PROFILES.LOCAL);
+  });
+
+  it('returns "supabase" for AUTH_PROFILE=supabase', () => {
+    vi.stubEnv('AUTH_PROFILE', 'supabase');
+    expect(getAuthProfile()).toBe(AUTH_PROFILES.SUPABASE);
+  });
+
+  it('returns "postgres" for AUTH_PROFILE=postgres', () => {
+    vi.stubEnv('AUTH_PROFILE', 'postgres');
+    expect(getAuthProfile()).toBe(AUTH_PROFILES.POSTGRES);
+  });
+
+  it('falls back to "local" for an unrecognised AUTH_PROFILE value', () => {
+    vi.stubEnv('AUTH_PROFILE', 'firebase');
+    expect(getAuthProfile()).toBe(AUTH_PROFILES.LOCAL);
+  });
+
+  it('is case-insensitive', () => {
+    vi.stubEnv('AUTH_PROFILE', 'SUPABASE');
+    expect(getAuthProfile()).toBe(AUTH_PROFILES.SUPABASE);
+  });
+
+  it('trims whitespace', () => {
+    vi.stubEnv('AUTH_PROFILE', '  postgres  ');
+    expect(getAuthProfile()).toBe(AUTH_PROFILES.POSTGRES);
+  });
+});
+
+describe('isExternalAuthProfile', () => {
+  it('returns false for the local profile', () => {
+    expect(isExternalAuthProfile(AUTH_PROFILES.LOCAL)).toBe(false);
+  });
+
+  it('returns true for the supabase profile', () => {
+    expect(isExternalAuthProfile(AUTH_PROFILES.SUPABASE)).toBe(true);
+  });
+
+  it('returns true for the postgres profile', () => {
+    expect(isExternalAuthProfile(AUTH_PROFILES.POSTGRES)).toBe(true);
+  });
+});

--- a/src/server/config/redirects.test.ts
+++ b/src/server/config/redirects.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { getRedirectRule } from './redirects';
+
+describe('getRedirectRule', () => {
+  it('returns the redirect rule for /privacy', () => {
+    const rule = getRedirectRule('/privacy');
+    expect(rule).toBeDefined();
+    expect(rule?.to).toBe('/policies');
+    expect(rule?.status).toBe(301);
+  });
+
+  it('returns the redirect rule for /terms', () => {
+    const rule = getRedirectRule('/terms');
+    expect(rule).toBeDefined();
+    expect(rule?.to).toBe('/policies');
+    expect(rule?.status).toBe(301);
+  });
+
+  it('returns undefined for an unknown path', () => {
+    expect(getRedirectRule('/unknown-route')).toBeUndefined();
+  });
+
+  it('returns undefined for the home route', () => {
+    expect(getRedirectRule('/')).toBeUndefined();
+  });
+
+  it('normalizes a trailing slash on the incoming path', () => {
+    // /privacy/ should match the /privacy rule
+    const rule = getRedirectRule('/privacy/');
+    expect(rule).toBeDefined();
+    expect(rule?.to).toBe('/policies');
+  });
+
+  it('does not strip the trailing slash from the root path', () => {
+    // "/" is special — trailing-slash removal must not turn it into ""
+    expect(getRedirectRule('/')).toBeUndefined();
+  });
+});

--- a/src/server/middleware/error-handler.test.ts
+++ b/src/server/middleware/error-handler.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { globalErrorHandler } from './error-handler';
+import type { ApiErrorResponse } from '../config/api-error';
+
+const makeReq = (path: string, method = 'GET'): Partial<Request> =>
+  ({ path, method }) as Partial<Request>;
+
+const makeRes = () => {
+  const res = {
+    status: vi.fn(),
+    json: vi.fn(),
+    redirect: vi.fn(),
+  };
+  // Allow chaining: res.status(n).json(...)
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  res.redirect.mockReturnValue(res);
+  return res;
+};
+
+const makeNext = (): NextFunction => vi.fn() as NextFunction;
+
+const makeErr = (overrides: Partial<ApiErrorResponse & Error> = {}): ApiErrorResponse & Error => ({
+  status: 500,
+  code: 'INTERNAL_ERROR',
+  message: 'Something went wrong',
+  name: 'Error',
+  ...overrides,
+} as ApiErrorResponse & Error);
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+describe('globalErrorHandler', () => {
+  describe('API routes (/api/*)', () => {
+    it('responds with JSON and the error status', () => {
+      const err = makeErr({ status: 403, code: 'FORBIDDEN', message: 'Access denied' });
+      const req = makeReq('/api/session');
+      const res = makeRes();
+
+      globalErrorHandler(err, req as Request, res as unknown as Response, makeNext());
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 403, code: 'FORBIDDEN', message: 'Access denied' })
+      );
+    });
+
+    it('falls back to an INTERNAL_ERROR shape when code is absent', () => {
+      const err = { status: 500, message: 'Oops', name: 'Error' } as ApiErrorResponse & Error;
+      const req = makeReq('/api/key');
+      const res = makeRes();
+
+      globalErrorHandler(err, req as Request, res as unknown as Response, makeNext());
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'INTERNAL_ERROR' })
+      );
+    });
+  });
+
+  describe('Page routes (non-/api/*)', () => {
+    it('redirects to the home route', () => {
+      const err = makeErr({ status: 404 });
+      const req = makeReq('/some-page');
+      const res = makeRes();
+
+      globalErrorHandler(err, req as Request, res as unknown as Response, makeNext());
+
+      expect(res.redirect).toHaveBeenCalledWith('/');
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
+    it('sets the error status code on the redirect', () => {
+      const err = makeErr({ status: 404 });
+      const req = makeReq('/missing');
+      const res = makeRes();
+
+      globalErrorHandler(err, req as Request, res as unknown as Response, makeNext());
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+});

--- a/src/server/services/auth.test.ts
+++ b/src/server/services/auth.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { hashPassword, localUser } from './auth';
+
+describe('hashPassword', () => {
+  it('produces the stored hash for the default test credentials', () => {
+    // Regression test: ensures the stored hash in localUser stays in sync
+    // with the hashPassword implementation. If either changes, this fails.
+    const result = hashPassword('test', localUser.salt);
+    expect(result).toBe(localUser.password);
+  });
+
+  it('returns a hex string', () => {
+    const result = hashPassword('password', 'somesalt');
+    expect(result).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('produces different hashes for different passwords', () => {
+    const hash1 = hashPassword('password1', 'salt');
+    const hash2 = hashPassword('password2', 'salt');
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it('produces different hashes for different salts', () => {
+    const hash1 = hashPassword('password', 'salt1');
+    const hash2 = hashPassword('password', 'salt2');
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it('is deterministic — same inputs always produce the same hash', () => {
+    const a = hashPassword('mypassword', 'mysalt');
+    const b = hashPassword('mypassword', 'mysalt');
+    expect(a).toBe(b);
+  });
+});

--- a/src/server/services/jwt.test.ts
+++ b/src/server/services/jwt.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { signToken, verifyToken, type JwtPayload } from './jwt';
+
+// SESSION_SECRET is set to a test value in vitest.config.ts via test.env
+// before this module is imported, so JWT_SECRET is populated correctly.
+
+const TEST_PAYLOAD: JwtPayload = { email: 'alice@example.com', name: 'Alice' };
+
+describe('signToken', () => {
+  it('returns a non-empty string', () => {
+    const token = signToken(TEST_PAYLOAD);
+    expect(typeof token).toBe('string');
+    expect(token.length).toBeGreaterThan(0);
+  });
+
+  it('produces a three-part JWT (header.payload.signature)', () => {
+    const token = signToken(TEST_PAYLOAD);
+    expect(token.split('.')).toHaveLength(3);
+  });
+});
+
+describe('verifyToken', () => {
+  it('returns the original payload for a valid token', () => {
+    const token = signToken(TEST_PAYLOAD);
+    const result = verifyToken(token);
+    expect(result).not.toBeNull();
+    expect(result?.email).toBe(TEST_PAYLOAD.email);
+    expect(result?.name).toBe(TEST_PAYLOAD.name);
+  });
+
+  it('returns null for a malformed token string', () => {
+    expect(verifyToken('not-a-jwt')).toBeNull();
+  });
+
+  it('returns null for a token signed with a different secret', () => {
+    // Manually craft a token with a wrong secret to simulate tampering
+    const tamperedToken = 'eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3QifQ.wrongsig';
+    expect(verifyToken(tamperedToken)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(verifyToken('')).toBeNull();
+  });
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -20,5 +20,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    // Make describe/it/expect available without explicit imports.
+    globals: true,
+
+    // Set env vars before any module-level code runs.
+    // SESSION_SECRET must be present when jwt.ts is first imported
+    // (it reads the var at module initialization time).
+    env: {
+      SESSION_SECRET: 'vitest-test-secret-do-not-use-in-production',
+    },
+
+    // Run server tests in a real Node environment;
+    // run client tests in a simulated browser environment.
+    environmentMatchGlobs: [
+      ['src/server/**', 'node'],
+      ['src/client/**', 'happy-dom'],
+    ],
+
+    // Isolate modules between test files so module-level state
+    // (e.g. JWT_SECRET, ENV_FEATURE_FLAGS) doesn't bleed across suites.
+    isolate: true,
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces Vitest 4 as the unit test layer alongside the existing Cypress E2E suite. Resolves the tension the issue raised about agents adding their own ad-hoc test tooling by establishing a clear, ready-to-extend convention.

Closes #163

## What's included

### Infrastructure

| File | Purpose |
|------|---------|
| `vitest.config.ts` | Vitest config with per-directory environment mapping and test env vars |
| `tsconfig.node.json` | Added `vitest.config.ts` to `include` so ESLint can parse it |
| `package.json` | Added `test:unit` script; `test` now runs lint → type-check → unit → E2E |

### Test files (co-located as `*.test.ts`)

**Server — `environment: node`**

| File | Coverage |
|------|---------|
| `src/server/config/api-error.test.ts` | `createApiError`, all `API_ERRORS` factories with default + custom args |
| `src/server/config/redirects.test.ts` | `getRedirectRule` — known routes, trailing-slash normalisation, unknown paths |
| `src/server/config/auth-profile.test.ts` | `getAuthProfile` — env var mapping, fallbacks, case-insensitivity, whitespace trimming; `isExternalAuthProfile` |
| `src/server/services/auth.test.ts` | `hashPassword` — regression against stored fixture, determinism, input sensitivity |
| `src/server/services/jwt.test.ts` | `signToken` + `verifyToken` round-trip, malformed/tampered/empty token rejection |
| `src/server/middleware/error-handler.test.ts` | API route → JSON response; page route → redirect; missing `code` fallback |

**Client — `environment: happy-dom`**

| File | Coverage |
|------|---------|
| `src/client/utilities/feature-flags.test.ts` | `parseFeatureFlags` — all truthy/falsy string values, multi-flag, whitespace, missing value default; `isFeatureEnabled` — override precedence, unknown flag default |
| `src/client/utilities/formatting.test.ts` | `formatDate`, `formatNumber`, `formatCurrency` with pinned `en-US` locale for deterministic assertions |

### Docs updated

- `README.md` — added `test:unit` to features list and quick-command table; updated requirements note
- `docs/SCRIPTS.md` — added full `test:unit` section; updated `test` description; added unit test requirements and troubleshooting entry

## Key design decisions

- **Co-location**: test files sit next to their source (`foo.ts` / `foo.test.ts`), consistent with how most Vitest projects are organized.
- **`environmentMatchGlobs`**: `src/server/**` → `node`; `src/client/**` → `happy-dom`. This ensures server code is never run in a browser-like context and vice versa.
- **`SESSION_SECRET` in `test.env`**: `jwt.ts` reads `process.env.SESSION_SECRET` at module initialization time. Setting it in `vitest.config.ts`'s `test.env` ensures it's available before any test file imports the module.
- **No snapshot tests**: snapshots tend to become stale and break on unrelated changes. Explicit assertions are used throughout.

## Results

```
 Test Files  8 passed (8)
      Tests  69 passed (69)
   Duration  ~500ms
```

All 25 Cypress E2E tests also continue to pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8c910e5-7f21-41f4-885c-b57ebbae4d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8c910e5-7f21-41f4-885c-b57ebbae4d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

