### PR TITLE
chore: upgrade TypeScript to 6.0.3 and react-intl to 10.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated runtime dependencies: `@chakra-ui/react` 3.33.0→3.35.0, `framer-motion` 12.34.3→12.38.0, `react`/`react-dom` 19.2.4→19.2.6, `react-icons` 5.5.0→5.6.0, `react-router` 7.13.1→7.15.0.
 - Updated `@types/node` 24.7.2→25.7.0 (compatible with TypeScript 5.9).
 - Moved `new Date().getFullYear()` in `Footer` to a module-level constant to satisfy the new `react-x/purity` rule.
+- Upgraded TypeScript 5.9.3→6.0.3. TypeScript 6 is a transition release bridging 5.x and the forthcoming Go-based 7.0; it introduces new compiler defaults (`strict`, `target`, `moduleResolution`) and deprecates legacy options. The existing `tsconfig.app.json` and `tsconfig.node.json` already used explicit values for all changed defaults, so no tsconfig edits were required.
+- Upgraded `react-intl` 8.1.3→10.1.8. Version 10 requires React 19 and TypeScript 5+ (both already satisfied). The project uses only stable APIs (`IntlProvider`, `FormattedMessage`, `useIntl`) — none of the deprecated `FormattedHTMLMessage`/`intl.formatHTMLMessage` APIs — so no source changes were required.
 
 ### Removed
 
 - Removed unused `ejs` dependency (template system was removed in v1.2.0 but the package lingered).
-
-### Deferred (intentional holds)
-- `typescript` 6: Requires validating the pre-existing `encryption.ts` type error and downstream tooling.
-- `react-intl` 10: Major breaking changes to the message API.
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,11 +26,11 @@
         "react-dom": "^19.2.6",
         "react-error-boundary": "6.1.1",
         "react-icons": "^5.6.0",
-        "react-intl": "8.1.3",
+        "react-intl": "10.1.8",
         "react-redux": "9.2.0",
         "react-router": "^7.15.0",
         "tsx": "4.21.0",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vite-express": "0.22.1"
       },
       "devDependencies": {
@@ -1359,77 +1359,36 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.1.1.tgz",
-      "integrity": "sha512-jhZbTwda+2tcNrs4kKvxrPLPjx8QsBCLCUgrrJ/S+G9YrGHWLhAyFMMBHJBnBoOwuLHd7L14FgYudviKaxkO2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/intl-localematcher": "0.8.1",
-        "decimal.js": "^10.6.0",
-        "tslib": "^2.8.1"
-      }
-    },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.0.tgz",
-      "integrity": "sha512-b5mvSWCI+XVKiz5WhnBCY3RJ4ZwfjAidU0yVlKa3d3MSgKmH1hC3tBGEAtYyN5mqL7N0G5x0BOUYyO8CEupWgg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.5.tgz",
+      "integrity": "sha512-KLi3fan6WnCHmigd9pmEEN8Hid0v4wiFBW576M/d07KMWYecf1CvyMI3n34vCmHT4AoVqG2n702kiHbXjzZX2A==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.1.tgz",
-      "integrity": "sha512-sSDmSvmmoVQ92XqWb499KrIhv/vLisJU8ITFrx7T7NZHUmMY7EL9xgRowAosaljhqnj/5iufG24QrdzB6X3ItA==",
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.9.tgz",
+      "integrity": "sha512-PZm6O9JI/gUPtQV9r2eaMuLb4yWqV2vz+ot03ORHWTKO343LSpZi0TqeXLB2ZZGDXLCw2SbfgsQ0GxoxXMl79g==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/icu-skeleton-parser": "2.1.1",
-        "tslib": "^2.8.1"
+        "@formatjs/icu-skeleton-parser": "2.1.9"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.1.tgz",
-      "integrity": "sha512-PSFABlcNefjI6yyk8f7nyX1DC7NHmq6WaCHZLySEXBrXuLOB2f935YsnzuPjlz+ibhb9yWTdPeVX1OVcj24w2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "tslib": "^2.8.1"
-      }
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.9.tgz",
+      "integrity": "sha512-rsxswgHMfU1zUgB2byc08fesf83wLGjFnzLCEtuf00mx2doiqc6pYrf67raI37XqdRcGUviQepk2UKGqpng74Q==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/intl": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.2.tgz",
-      "integrity": "sha512-V60fNY/X/7zqmRffr7qPwscGmVGYDmlKF069mSQ2a/7fE22q602NtIfOQY8vzRA63Gr/O/U6vjRVBHMabrnA9A==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.11.tgz",
+      "integrity": "sha512-CB0mZTbnVCgnZDpOwDUGp6tC6cRl8C8gbpqvP0aatwkcRdazgXctCppljnVU3nzG0yuOABO1+DDRekESiitNmA==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/icu-messageformat-parser": "3.5.1",
-        "intl-messageformat": "11.1.2",
-        "tslib": "^2.8.1"
-      },
-      "peerDependencies": {
-        "typescript": "^5.6.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.1.tgz",
-      "integrity": "sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "tslib": "^2.8.1"
+        "@formatjs/fast-memoize": "3.1.5",
+        "@formatjs/icu-messageformat-parser": "3.5.9",
+        "intl-messageformat": "11.2.6"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2158,18 +2117,6 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
-      }
-    },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
-      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "license": "MIT",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/http-errors": {
@@ -4269,12 +4216,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/decimal.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT"
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5508,15 +5449,13 @@
       "license": "ISC"
     },
     "node_modules/intl-messageformat": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.1.2.tgz",
-      "integrity": "sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.6.tgz",
+      "integrity": "sha512-afAN2yNN7zjB77G1ZC5L8GtLrEshyBvOQXz88flxCO/ocTIQist98gu0r/O6H/SSiQhQsOOtWPxmCEvtDABXXQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/icu-messageformat-parser": "3.5.1",
-        "tslib": "^2.8.1"
+        "@formatjs/fast-memoize": "3.1.5",
+        "@formatjs/icu-messageformat-parser": "3.5.9"
       }
     },
     "node_modules/ip-address": {
@@ -6908,28 +6847,18 @@
       }
     },
     "node_modules/react-intl": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-8.1.3.tgz",
-      "integrity": "sha512-eL1/d+uQdnapirynOGAriW0K9uAoyarjRGL3V9LaTRuohNSvPgCfJX06EZl5M52h/Hu7Gz7A1sD7dNHcos1lNg==",
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-10.1.8.tgz",
+      "integrity": "sha512-+iBzzkykXkZ2/9zI8LnDmfCobgz33J+r+24QbX4dJJ4f6rO1LuFwqv39kSTloZdPm9yYcnJOrvz0MqyCa6XeXQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/icu-messageformat-parser": "3.5.1",
-        "@formatjs/intl": "4.1.2",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "hoist-non-react-statics": "^3.3.2",
-        "intl-messageformat": "11.1.2",
-        "tslib": "^2.8.1"
+        "@formatjs/icu-messageformat-parser": "3.5.9",
+        "@formatjs/intl": "4.1.11",
+        "intl-messageformat": "11.2.6"
       },
       "peerDependencies": {
         "@types/react": "19",
-        "react": "19",
-        "typescript": "^5.6.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "react": "19"
       }
     },
     "node_modules/react-is": {
@@ -7593,27 +7522,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.5.tgz",
-      "integrity": "sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -7678,9 +7586,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7944,6 +7852,27 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
     "react-dom": "^19.2.6",
     "react-error-boundary": "6.1.1",
     "react-icons": "^5.6.0",
-    "react-intl": "8.1.3",
+    "react-intl": "10.1.8",
     "react-redux": "9.2.0",
     "react-router": "^7.15.0",
     "tsx": "4.21.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite-express": "0.22.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #176

## Summary

Upgrades the two packages deferred in the previous release cycle:

### TypeScript 5.9.3 → 6.0.3

TypeScript 6 is a transition release bridging the JS-based 5.x line and the forthcoming Go-based TypeScript 7.0. Key behavioral changes:

| Option | 5.9 default | 6.0 default | Our config |
|---|---|---|---|
| `strict` | `false` | `true` | already `true` |
| `target` | `ES3` | `es2025` | explicitly `ESNext` |
| `moduleResolution` | `node10` | `bundler` | explicitly `bundler` |
| `types` | all `@types/*` | `[]` | not set — verified no Node globals leak into client code |
| `noUncheckedSideEffectImports` | `false` | `true` | already `true` |

Both `tsconfig.app.json` and `tsconfig.node.json` already set explicit values for every changed default, so **no tsconfig edits were required**. `npm run type-check` (`tsc --noEmit`) exits clean. The pre-existing build-time error in `encryption.ts` (unrelated to this upgrade) is unchanged.

### react-intl 8.1.3 → 10.1.8

Version 10 requires React 19 and TypeScript 5+ (both already satisfied). The project uses only stable, non-deprecated APIs (`IntlProvider`, `FormattedMessage`, `useIntl`) — none of the removed `FormattedHTMLMessage` / `intl.formatHTMLMessage` surface — so **no source changes were required**.

## Testing

- ✅ `npm run type-check` — zero errors
- ✅ `npm run lint` — zero errors (pre-existing `react-refresh/only-export-components` warning in `i18n.tsx` is unrelated and unchanged)
- ✅ `npm run test:unit` — 69/69 tests pass
- ✅ `npm run test:e2e` — 25/25 Playwright tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e548cfab-ee7f-46ce-96eb-0a0b98a245cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e548cfab-ee7f-46ce-96eb-0a0b98a245cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

